### PR TITLE
SYS-1970: Reformat dict returned by `get_mams_metadata`

### DIFF
--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -1,5 +1,6 @@
 # Code which extracts data from a Digital Data record.
 # Minimal for now.
+from uuid import UUID
 
 
 def get_file_name(dd_record: dict) -> str:
@@ -8,3 +9,7 @@ def get_file_name(dd_record: dict) -> str:
 
 def get_dd_record_id(dd_record: dict) -> int:
     return dd_record.get("id", 0)
+
+
+def get_uuid(dd_record: dict) -> UUID | str:
+    return dd_record.get("uuid", "")

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -10,21 +10,20 @@ from .marc import (
     get_language_name,
     get_title_info,
 )
-from uuid import UUID
 
 
 def get_mams_metadata(
     bib_record: Pymarc_Record,
     filemaker_record: FM_Record,
     digitaL_data_record: dict,
-    match_asset_uuid: UUID = None,
+    match_asset_uuid: str | None = None,
 ) -> dict:
     """Generate JSON metadata for ingest into the FTVA MAMS.
 
     :param bib_record: A pymarc record, expected to contain bibliographic data.
     :param filemaker_record: A fmrest filemaker record.
     :param digital_data_record: A dict containing an FTVA digital data record.
-    :param match_asset_uuid: A UUID to match a track to an asset, if one exists.
+    :param match_asset_uuid: A string representation of an asset's UUID. Defaults to None.
     :return asset: A dict of metadata combined from the input records.
     """
 


### PR DESCRIPTION
Implements [SYS-1970]()

### Acceptance criteria
- [x] Update `mams_metadata.py` and supporting code to implement the new [JSON structure](https://uclalibrary.atlassian.net/wiki/x/G4AlU).
- [x] Add `uuid` field from Digital Data
- [x] Change `creator` key to creators
- [x] Leave `inventory_number` key singular.

### Description
The changes in this PR reformat the dict returned by the `mams_metadata.py` module to match the currents specs worked out with FTVA.

Running the [json_tester_secret.py](https://gist.github.com/akohler/843562f2aafdfef0df29973f6d234b1a) script described in PR #2 should yield a metadata record with the same format as the single `asset` in the example JSON structure linked above, or as a `track` if a `match_asset_uuid` is provided.

### Testing
All 10 tests related to the `marc.py` module should still pass with these changes applied.

[SYS-1970]: https://uclalibrary.atlassian.net/browse/SYS-1970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ