### PR TITLE
SYS-1988: Add `media_type` to metadata record

### DIFF
--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -13,3 +13,7 @@ def get_dd_record_id(dd_record: dict) -> int:
 
 def get_uuid(dd_record: dict) -> UUID | str:
     return dd_record.get("uuid", "")
+
+
+def get_media_type(dd_record: dict) -> str:
+    return dd_record.get("media_type", "")

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -1,7 +1,7 @@
 import spacy
 from fmrest.record import Record as FM_Record
 from pymarc import Record as Pymarc_Record
-from .digital_data import get_file_name, get_uuid
+from .digital_data import get_file_name, get_uuid, get_media_type
 from .filemaker import get_inventory_id, get_inventory_number
 from .marc import (
     get_bib_id,
@@ -15,7 +15,7 @@ from .marc import (
 def get_mams_metadata(
     bib_record: Pymarc_Record,
     filemaker_record: FM_Record,
-    digitaL_data_record: dict,
+    digital_data_record: dict,
     match_asset_uuid: str | None = None,
 ) -> dict:
     """Generate JSON metadata for ingest into the FTVA MAMS.
@@ -40,12 +40,13 @@ def get_mams_metadata(
     metadata = {
         "alma_bib_id": get_bib_id(bib_record),
         "inventory_id": get_inventory_id(filemaker_record),
-        "uuid": get_uuid(digitaL_data_record),
+        "uuid": get_uuid(digital_data_record),
         "inventory_number": get_inventory_number(filemaker_record),
         "creators": get_creators(bib_record, nlp_model),
         "release_broadcast_date": get_date(bib_record),
         "language": get_language_name(bib_record),
-        "file_name": get_file_name(digitaL_data_record),
+        "file_name": get_file_name(digital_data_record),
+        "media_type": get_media_type(digital_data_record),
         **titles,
     }
 


### PR DESCRIPTION
Implements [SYS-1988](https://uclalibrary.atlassian.net/browse/SYS-1988)

### Acceptance criteria
- [x] The new `media_type` field from Digital Data application is added to the JSON generated by the FTVA ETL `get_mams_metadata()` method
- [x] Apply this to track as well as asset for consistency

### Description
Straightforward changes to add `media_type` to the JSON metadata record output by `get_mams_metadata()`.

There was also a capital L in the `digital_data_record` parameter of `get_mams_metadata`, so I changed that to a lower-case l.

### Testing
The `json_tester_secret.py` [demo script](https://gist.github.com/akohler/843562f2aafdfef0df29973f6d234b1a) should include the new `media_type` field.

[SYS-1988]: https://uclalibrary.atlassian.net/browse/SYS-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ