### PR TITLE
SYS-1991: Add DCP metadata

### DIFF
--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -22,12 +22,10 @@ def get_media_type(dd_record: dict) -> str:
 def get_dcp_info(dd_record: dict) -> dict | None:
     dcp_info = {}
     file_type = dd_record.get("file_type", "")
-    folder_name = dd_record.get("file_folder_name", "")
     if file_type == "DCP":
-        if "DCP" in folder_name:
-            dcp_info["asset_type"] = "Exhibition Copy"
-            dcp_info["file_name"] = ""
-            dcp_info["folder_name"] = dd_record.get("file_folder_name", "")
-            dcp_info["sub_folder_name"] = dd_record.get("sub_folder_name", "")
-            return dcp_info
+        dcp_info["asset_type"] = "Exhibition Copy"
+        dcp_info["file_name"] = ""
+        dcp_info["folder_name"] = dd_record.get("file_folder_name", "")
+        dcp_info["sub_folder_name"] = dd_record.get("sub_folder_name", "")
+        return dcp_info
     return None

--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -17,3 +17,17 @@ def get_uuid(dd_record: dict) -> UUID | str:
 
 def get_media_type(dd_record: dict) -> str:
     return dd_record.get("media_type", "")
+
+
+def get_dcp_info(dd_record: dict) -> dict | None:
+    dcp_info = {}
+    file_type = dd_record.get("file_type", "")
+    folder_name = dd_record.get("file_folder_name", "")
+    if file_type == "DCP":
+        if "DCP" in folder_name:
+            dcp_info["asset_type"] = "Exhibition Copy"
+            dcp_info["file_name"] = ""
+            dcp_info["folder_name"] = dd_record.get("file_folder_name", "")
+            dcp_info["sub_folder_name"] = dd_record.get("sub_folder_name", "")
+            return dcp_info
+    return None

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -1,7 +1,7 @@
 import spacy
 from fmrest.record import Record as FM_Record
 from pymarc import Record as Pymarc_Record
-from .digital_data import get_file_name, get_uuid, get_media_type
+from .digital_data import get_file_name, get_uuid, get_media_type, get_dcp_info
 from .filemaker import get_inventory_id, get_inventory_number
 from .marc import (
     get_bib_id,
@@ -36,6 +36,8 @@ def get_mams_metadata(
     # This gets a collection of titles which will be unpacked later.
     titles = get_title_info(bib_record)
 
+    dcp_info = get_dcp_info(digital_data_record)
+
     # Get the rest of the data and prepare it for return.
     metadata = {
         "alma_bib_id": get_bib_id(bib_record),
@@ -50,8 +52,13 @@ def get_mams_metadata(
         **titles,
     }
 
-    # If a match_asset_uuid is provided for a track, add it to the metadata record
+    # If a match_asset_uuid is provided for a track, add it to the metadata record.
     if match_asset_uuid:
         metadata["match_asset"] = match_asset_uuid
+
+    # If DCP info is present, update the metadata record with it.
+    # Note that `file_name` will be overwritten for DCPs.
+    if dcp_info is not None:
+        metadata.update(dcp_info)
 
     return metadata

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -58,7 +58,7 @@ def get_mams_metadata(
 
     # If DCP info is present, update the metadata record with it.
     # Note that `file_name` will be overwritten for DCPs.
-    if dcp_info is not None:
+    if dcp_info:
         metadata.update(dcp_info)
 
     return metadata


### PR DESCRIPTION
Implements [SYS-1991](https://uclalibrary.atlassian.net/browse/SYS-1991)

### Acceptance criteria
- [x] When `file_type` == DCP:
  - [x] If `folder_name` contains “DCP”:
    - [x] asset_type == “Exhibition Copy”
    - [x] file_name == ““
    - [x] folder_name == `file_folder_name` from Digital Data record
    - [x] sub_folder_name == `sub_folder_name` from Digital Data record

### Description
These changes handle records for DCP files, adding specific rules to the metadata creation function.

From the Systems Team meeting today, it sounds like DCPs will not be included in the next round of JSON samples sent to Callum, but I figured I'd push the changes anyway, as it should not affect other types of files.

One note is that the `file_folder_name` field key from the DD record is transformed to `folder_name`. Just flagging this, as that's how it appears in the [specs](https://uclalibrary.atlassian.net/wiki/x/fYAXTQ), but I'm not sure if that's a deliberate change or not.

### Testing
Inventory number `M72192` with DD record ID `2616` works locally as an example 1-1-1 record for use in the `json_tester_secret.py` [demo script](https://gist.github.com/akohler/843562f2aafdfef0df29973f6d234b1a).

[SYS-1991]: https://uclalibrary.atlassian.net/browse/SYS-1991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ