### PR TITLE
SYS-1999: Update title logic

### DIFF
--- a/src/ftva_etl/metadata/marc.py
+++ b/src/ftva_etl/metadata/marc.py
@@ -190,6 +190,7 @@ def get_title_info(bib_record: Record) -> dict:
 
     :param bib_record: Pymarc Record object containing the bib data.
     :return: A dict with available title info.
+    :raises ValueError: If no title statement (245 field) or main title (245$a) is found.
     """
     titles = {}
     record_id = get_record_id(bib_record)  # Used for ValueError messages
@@ -228,12 +229,18 @@ def get_title_info(bib_record: Record) -> dict:
 
     # CASE 2: Main title and name of part, but no number of part
     if main_title and name_of_part and not number_of_part:
-        titles["series_title"] = ". ".join([main_title, name_of_part])
+        # `title` is the same as `series_title` in this case
+        main_and_series_title = ". ".join([main_title, name_of_part])
+        titles["title"] = main_and_series_title
+        titles["series_title"] = main_and_series_title
         titles["episode_title"] = name_of_part
 
     # CASE 1: Main title, name of part, and number of part
     if main_title and name_of_part and number_of_part:
-        titles["series_title"] = ". ".join([main_title, name_of_part, number_of_part])
+        # `title` is the same as `series_title` in this case
+        main_and_series_title = ". ".join([main_title, name_of_part, number_of_part])
+        titles["title"] = main_and_series_title
+        titles["series_title"] = main_and_series_title
         titles["episode_title"] = ". ".join([name_of_part, number_of_part])
 
     return titles

--- a/src/ftva_etl/metadata/utils.py
+++ b/src/ftva_etl/metadata/utils.py
@@ -42,4 +42,6 @@ def strip_whitespace_and_punctuation(items: list[str]) -> list[str]:
     :param items: A list of strings to strip.
     :return: The list of strings with whitespace and punctuation stripped.
     """
-    return [item.rstrip(string.punctuation).strip() for item in items]
+    # Add space to right-strip of punctuation to handle spaces after punctuation,
+    # then explicitly strip square brackets and spaces from resulting string.
+    return [item.rstrip(string.punctuation + " ").strip("[] ") for item in items]

--- a/tests/test_metadata/test_marc.py
+++ b/tests/test_metadata/test_marc.py
@@ -110,6 +110,7 @@ class TestMarcTitlesRegion(TestCase):
         )
         titles = get_title_info(record)
         expected_result = {
+            "title": "Main Title. Name of Part. Number of Part",
             "series_title": "Main Title. Name of Part. Number of Part",
             "episode_title": "Name of Part. Number of Part",
         }
@@ -132,6 +133,7 @@ class TestMarcTitlesRegion(TestCase):
         )
         titles = get_title_info(record)
         expected_result = {
+            "title": "Main Title. Name of Part",
             "series_title": "Main Title. Name of Part",
             "episode_title": "Name of Part",
         }
@@ -212,6 +214,7 @@ class TestMarcTitlesRegion(TestCase):
         )
         titles = get_title_info(record)
         expected_result = {
+            "title": "Main Title. Name of Part. Number of Part",
             "series_title": "Main Title. Name of Part. Number of Part",
             "episode_title": "Name of Part. Number of Part",
         }


### PR DESCRIPTION
Implements [SYS-1999](https://uclalibrary.atlassian.net/browse/SYS-1999)

### Acceptance criteria
- [x] `get_title_info()` and supporting methods in the `marc` module are updated to reflect changes in the [specs](https://uclalibrary.atlassian.net/wiki/x/fYAXTQ) for Title (unqualified), Series Title, and Episode Title.
- [x] Add / update tests for all covered permutations of 245 $a $n $p

### Description
This PR updates the `get_title_info()` function in the `marc.py` module to match the new specs from FTVA. The logic is consolidated into `get_title_info`, with conditionals matching the 4 cases outlined in the specs. I chose to go in reverse order with the cases, both to fail early if there is no main title (`245$a`) field, and because I found it a little easier to reason about in that order.

As discussed at standup, the function will raise a `ValueError` if either `245` or `245$a` is missing. The caller, for example in our `generate_metadata` script, will need to handle these exceptions, though they should be few and far between.

I also updated the `strip_whitespace_and_punctuation` to account for two new cases:
1. trailing whitespace _after_ a punctuation character; and
2. removing square brackets `[]`, which I think we decided were to be removed (correct me if I'm wrong!)

### Testing
I added 7 new tests, 4 to cover the main spec cases, 2 to cover the error conditions, and 1 for testing character stripping. 11 tests total in the package now.

[SYS-1999]: https://uclalibrary.atlassian.net/browse/SYS-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ