### PR TITLE
SYS-1998: Fix non-MARC bugs from test batch 1

### DIFF
--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -15,6 +15,10 @@ def get_uuid(dd_record: dict) -> UUID | str:
     return dd_record.get("uuid", "")
 
 
+def get_asset_type(dd_record: dict) -> str:
+    return dd_record.get("asset_type", "")
+
+
 def get_media_type(dd_record: dict) -> str:
     return dd_record.get("media_type", "")
 

--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -7,6 +7,14 @@ def get_file_name(dd_record: dict) -> str:
     return dd_record.get("file_name", "")
 
 
+def get_folder_name(dd_record: dict) -> str:
+    return dd_record.get("file_folder_name", "")
+
+
+def get_sub_folder_name(dd_record: dict) -> str:
+    return dd_record.get("sub_folder_name", "")
+
+
 def get_dd_record_id(dd_record: dict) -> int:
     return dd_record.get("id", 0)
 
@@ -23,13 +31,28 @@ def get_media_type(dd_record: dict) -> str:
     return dd_record.get("media_type", "")
 
 
-def get_dcp_info(dd_record: dict) -> dict | None:
-    dcp_info = {}
-    file_type = dd_record.get("file_type", "")
-    if file_type == "DCP":
-        dcp_info["asset_type"] = "Exhibition Copy"
-        dcp_info["file_name"] = ""
-        dcp_info["folder_name"] = dd_record.get("file_folder_name", "")
-        dcp_info["sub_folder_name"] = dd_record.get("sub_folder_name", "")
-        return dcp_info
-    return None
+def get_dcp_info(dd_record: dict) -> dict:
+    """Return a bundle of fields for DCP files.
+
+    :param dd_record: A Digital Data record
+    :return: A dictionary of fields.
+    """
+    return {
+        # File name must always be empty for DCPs.
+        "file_name": "",
+        "folder_name": get_folder_name(dd_record),
+        "sub_folder_name": get_sub_folder_name(dd_record),
+    }
+
+
+def get_dpx_info(dd_record: dict) -> dict:
+    """Return a bundle of fields for DPX files.
+
+    :param dd_record: A Digital Data record
+    :return: A dictionary of fields.
+    """
+    return {
+        # File name must always be empty for DPXs.
+        "file_name": "",
+        "folder_name": get_folder_name(dd_record),
+    }

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -4,6 +4,7 @@ from pymarc import Record as Pymarc_Record
 from .digital_data import (
     get_asset_type,
     get_dcp_info,
+    get_dpx_info,
     get_file_name,
     get_media_type,
     get_uuid,
@@ -42,8 +43,6 @@ def get_mams_metadata(
     # This gets a collection of titles which will be unpacked later.
     titles = get_title_info(bib_record)
 
-    dcp_info = get_dcp_info(digital_data_record)
-
     # Get the rest of the data and prepare it for return.
     metadata = {
         "alma_bib_id": get_bib_id(bib_record),
@@ -63,9 +62,14 @@ def get_mams_metadata(
     if match_asset_uuid:
         metadata["match_asset"] = match_asset_uuid
 
-    # If DCP info is present, update the metadata record with it.
-    # Note that `file_name` will be overwritten for DCPs.
-    if dcp_info:
-        metadata.update(dcp_info)
+    # Override some elements based on file type.
+    file_type = digital_data_record.get("file_type", "")
+    if file_type == "DCP":
+        metadata.update(get_dcp_info(digital_data_record))
+    elif file_type == "DPX":
+        metadata.update(get_dpx_info(digital_data_record))
+    else:
+        # No special action needed
+        pass
 
     return metadata

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -1,7 +1,13 @@
 import spacy
 from fmrest.record import Record as FM_Record
 from pymarc import Record as Pymarc_Record
-from .digital_data import get_file_name, get_uuid, get_media_type, get_dcp_info
+from .digital_data import (
+    get_asset_type,
+    get_dcp_info,
+    get_file_name,
+    get_media_type,
+    get_uuid,
+)
 from .filemaker import get_inventory_id, get_inventory_number
 from .marc import (
     get_bib_id,
@@ -48,6 +54,7 @@ def get_mams_metadata(
         "release_broadcast_date": get_date(bib_record),
         "language": get_language_name(bib_record),
         "file_name": get_file_name(digital_data_record),
+        "asset_type": get_asset_type(digital_data_record),
         "media_type": get_media_type(digital_data_record),
         **titles,
     }

--- a/tests/test_metadata/test_digital_data.py
+++ b/tests/test_metadata/test_digital_data.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+from src.ftva_etl.metadata.digital_data import get_dcp_info, get_dpx_info
+
+
+class TestDigitalData(TestCase):
+    def test_dcp_info(self):
+        # Very simple Digital Data record for DCP.
+        dcp_record = {
+            "file_type": "DCP",
+            "file_name": "not relevant",
+            "file_folder_name": "folder name",
+            "sub_folder_name": "sub folder name",
+        }
+
+        dcp_info = get_dcp_info(dcp_record)
+        # File name must be empty.
+        self.assertEqual(dcp_info["file_name"], "")
+        # Other values should match.
+        # Note that these methods may rename some field names, which is intentional.
+        self.assertEqual(dcp_info["folder_name"], "folder name")
+        self.assertEqual(dcp_info["sub_folder_name"], "sub folder name")
+
+    def test_dpx_info(self):
+        # Very simple Digital Data record for DPX.
+        dpx_record = {
+            "file_type": "DPX",
+            "file_name": "not relevant",
+            "file_folder_name": "folder name",
+            "sub_folder_name": "sub folder name",
+        }
+
+        dpx_info = get_dpx_info(dpx_record)
+        # File name must be empty.
+        self.assertEqual(dpx_info["file_name"], "")
+        # Other values should match.
+        # Note that these methods may rename some field names, which is intentional.
+        self.assertEqual(dpx_info["folder_name"], "folder name")
+        # For DPX, do not include subfolders.
+        self.assertNotIn("sub_folder_name", dpx_info)


### PR DESCRIPTION
Fixes [SYS-1998](https://uclalibrary.atlassian.net/browse/SYS-1998).

This PR fixes a few small bugs:
* `asset_type` not included in output
* DPX `file_type` not handled correctly
* ~`media_type` not included in output~ : This was already in the package; I think the `ftva_mams` container just didn't get updated with previous package changes.

When I added DPX support, I refactored the existing DCP code:
* Pulled field accessors into separate methods for reuse (trivial, but consistent)
* Moved the `file_type` decision-making to the main `get_mams_metadata()` method, since there now are multiple special cases
* Added basic tests for the DCP and DPX code to ensure `file_name` is being cleared and `sub_folder_name` is included only when appropriate.

#### Testing
`python -m unittest` (or `docker compose run ftva_etl python -m unittest`) now shows 12 tests, all passing.

I also updated the non-repo [src/json_tester_secret.py](https://gist.github.com/akohler/968364ced840fdd51d467e9b2de1829e) to run against a list of test DD ids, getting inventory number from each.  The list in this gist has ids for a DCP, a DPX, and a regular (video) file.





[SYS-1998]: https://uclalibrary.atlassian.net/browse/SYS-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ