### PR TITLE
SYS-2000: Update `series_title` to match spec revision

### DIFF
--- a/src/ftva_etl/metadata/marc.py
+++ b/src/ftva_etl/metadata/marc.py
@@ -229,18 +229,14 @@ def get_title_info(bib_record: Record) -> dict:
 
     # CASE 2: Main title and name of part, but no number of part
     if main_title and name_of_part and not number_of_part:
-        # `title` is the same as `series_title` in this case
-        main_and_series_title = ". ".join([main_title, name_of_part])
-        titles["title"] = main_and_series_title
-        titles["series_title"] = main_and_series_title
+        titles["title"] = ". ".join([main_title, name_of_part])
+        titles["series_title"] = main_title
         titles["episode_title"] = name_of_part
 
     # CASE 1: Main title, name of part, and number of part
     if main_title and name_of_part and number_of_part:
-        # `title` is the same as `series_title` in this case
-        main_and_series_title = ". ".join([main_title, name_of_part, number_of_part])
-        titles["title"] = main_and_series_title
-        titles["series_title"] = main_and_series_title
+        titles["title"] = ". ".join([main_title, name_of_part, number_of_part])
+        titles["series_title"] = main_title
         titles["episode_title"] = ". ".join([name_of_part, number_of_part])
 
     return titles

--- a/tests/test_metadata/test_marc.py
+++ b/tests/test_metadata/test_marc.py
@@ -111,7 +111,7 @@ class TestMarcTitlesRegion(TestCase):
         titles = get_title_info(record)
         expected_result = {
             "title": "Main Title. Name of Part. Number of Part",
-            "series_title": "Main Title. Name of Part. Number of Part",
+            "series_title": "Main Title",
             "episode_title": "Name of Part. Number of Part",
         }
         self.assertDictEqual(titles, expected_result)
@@ -134,7 +134,7 @@ class TestMarcTitlesRegion(TestCase):
         titles = get_title_info(record)
         expected_result = {
             "title": "Main Title. Name of Part",
-            "series_title": "Main Title. Name of Part",
+            "series_title": "Main Title",
             "episode_title": "Name of Part",
         }
         self.assertDictEqual(titles, expected_result)
@@ -215,7 +215,7 @@ class TestMarcTitlesRegion(TestCase):
         titles = get_title_info(record)
         expected_result = {
             "title": "Main Title. Name of Part. Number of Part",
-            "series_title": "Main Title. Name of Part. Number of Part",
+            "series_title": "Main Title",
             "episode_title": "Name of Part. Number of Part",
         }
         self.assertDictEqual(titles, expected_result)


### PR DESCRIPTION
Implements [SYS-2000](https://uclalibrary.atlassian.net/browse/SYS-2000)

### Acceptance criteria
- [x] Changes to Series Title are implemented.  See [specs](https://uclalibrary.atlassian.net/wiki/x/fYAXTQ) for details.
  - [Version comparison to focus on changes](https://uclalibrary.atlassian.net/wiki/pages/diffpagesbyversion.action?pageId=1293385853&selectedPageVersions=54&selectedPageVersions=53)

### Description
For Cases 1 and 2 of the `get_title_info` function in `marc.py`, the `series_title` attribute of the returned dict is now set to `main_title` (i.e. field `245 $a`), rather than repeating the concatenated value in the `title` attributes.

Other changes are just cleanup and updates to tests.

[SYS-2000]: https://uclalibrary.atlassian.net/browse/SYS-2000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ