### PR TITLE
SYS-2001: Cast `inventory_id` to string in `filemaker.py`

### DIFF
--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -5,7 +5,7 @@ from fmrest.record import Record
 
 
 def get_inventory_id(fm_record: Record) -> str:
-    return fm_record.inventory_id
+    return str(fm_record.inventory_id)
 
 
 def get_inventory_number(fm_record: Record) -> str:


### PR DESCRIPTION
Implements [SYS-2001](https://uclalibrary.atlassian.net/browse/SYS-2001)

### Acceptance criteria
- [X] The `inventory_id` field in the dict returned by `get_mams_metadata` is returned as a string

### Description
Straightforward change to the `get_inventory_id` function in the `filemaker.py` module, to cast value returned by FileMaker from `int` to `str`.

All 13 tests still pass.