### PR TITLE
SYS-2043: Update titles logic to reference `production_type` field from Filemaker

### DIFF
--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -10,3 +10,9 @@ def get_inventory_id(fm_record: Record) -> str:
 
 def get_inventory_number(fm_record: Record) -> str:
     return fm_record.inventory_no
+
+
+def is_series_production_type(fm_record: Record) -> bool:
+    production_type = fm_record.production_type
+    serial_keywords = ["television series", "mini-series", "serials", "news"]
+    return any(keyword in production_type.lower() for keyword in serial_keywords)

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -1,18 +1,37 @@
 from fmrest.record import Record
+from .utils import cleanup_production_type
 
 # Code which extracts data from a Filemaker record.
 # Minimal for now.
 
 
 def get_inventory_id(fm_record: Record) -> str:
+    """Get the inventory id from a Filemaker record.
+
+    :param fm_record: A Filemaker record.
+    :return: The inventory id as a string.
+    """
     return str(fm_record.inventory_id)
 
 
 def get_inventory_number(fm_record: Record) -> str:
+    """Get the inventory number from a Filemaker record.
+
+    :param fm_record: A Filemaker record.
+    :return: The inventory number as a string.
+    """
     return fm_record.inventory_no
 
 
 def is_series_production_type(fm_record: Record) -> bool:
-    production_type = fm_record.production_type
-    serial_keywords = ["television series", "mini-series", "serials", "news"]
-    return any(keyword in production_type.lower() for keyword in serial_keywords)
+    """Determine if the `production_type` field represents a series,
+    based on certain keywords defined in FTVA specs.
+
+    :param fm_record: A Filemaker record.
+    :return: True if the production type is a series, False otherwise.
+    """
+
+    production_type = cleanup_production_type(fm_record.production_type)
+    series_keywords = ["television series", "mini-series", "serials", "news"]
+    # Look for any of the keywords in the production type list
+    return any(keyword in production_type for keyword in series_keywords)

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -9,7 +9,7 @@ from .digital_data import (
     get_media_type,
     get_uuid,
 )
-from .filemaker import get_inventory_id, get_inventory_number
+from .filemaker import get_inventory_id, get_inventory_number, is_series_production_type
 from .marc import (
     get_bib_id,
     get_creators,
@@ -40,8 +40,11 @@ def get_mams_metadata(
     # may be for batch processing.
     nlp_model = spacy.load("en_core_web_md")
 
+    # Used for some special handling of serial titles
+    is_series = is_series_production_type(filemaker_record)
+
     # This gets a collection of titles which will be unpacked later.
-    titles = get_title_info(bib_record)
+    titles = get_title_info(bib_record, is_series)
 
     # Get the rest of the data and prepare it for return.
     metadata = {

--- a/src/ftva_etl/metadata/utils.py
+++ b/src/ftva_etl/metadata/utils.py
@@ -45,3 +45,17 @@ def strip_whitespace_and_punctuation(items: list[str]) -> list[str]:
     # Add space to right-strip of punctuation to handle spaces after punctuation,
     # then explicitly strip square brackets and spaces from resulting string.
     return [item.rstrip(string.punctuation + " ").strip("[] ") for item in items]
+
+
+def cleanup_production_type(production_type: str) -> list[str]:
+    """Cleanup the production_type string to allow series identification.
+
+    In the Filemaker PD, the production_type field is a list of strings,
+    often delimited by carriage returns (\r).
+    This function cleans up the string to allow series identification.
+
+    :param production_type: A string containing the production types.
+    :return: A list representation of the production types.
+    """
+    # Normalize to lowercase and split by carriage returns
+    return production_type.lower().split("\r")

--- a/tests/test_metadata/test_filemaker.py
+++ b/tests/test_metadata/test_filemaker.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+from src.ftva_etl.metadata.filemaker import (
+    is_series_production_type,
+)
+from fmrest.record import Record
+
+
+class TestFilemaker(TestCase):
+
+    def setUp(self):
+        valid_test_values = ["television series", "mini-series", "serials", "news"]
+        self.valid_test_records = [
+            Record(keys=["production_type"], values=[value])
+            for value in valid_test_values
+        ]
+
+        invalid_test_values = ["foo", "bar", "baz", "buz"]
+        self.invalid_test_records = [
+            Record(keys=["production_type"], values=[value])
+            for value in invalid_test_values
+        ]
+
+    def test_is_series_production_type(self):
+        for record in self.valid_test_records:
+            with self.subTest(record=record):
+                self.assertTrue(is_series_production_type(record))
+
+        for record in self.invalid_test_records:
+            with self.subTest(record=record):
+                self.assertFalse(is_series_production_type(record))

--- a/tests/test_metadata/test_filemaker.py
+++ b/tests/test_metadata/test_filemaker.py
@@ -6,21 +6,37 @@ from fmrest.record import Record
 
 
 class TestFilemaker(TestCase):
-
-    def setUp(self):
-        valid_test_values = ["television series", "mini-series", "serials", "news"]
-        self.valid_test_records = [
-            Record(keys=["production_type"], values=[value])
-            for value in valid_test_values
-        ]
-
-        invalid_test_values = ["foo", "bar", "baz", "buz"]
-        self.invalid_test_records = [
-            Record(keys=["production_type"], values=[value])
-            for value in invalid_test_values
-        ]
-
     def test_is_series_production_type(self):
+        # Cherry-picked data from Filemaker PD that should be identified as series
+        valid_test_cases = [
+            "NEWS\rCOMPILATION",
+            "TELEVISION SERIES\rCOMEDY",
+            "MINI-SERIES\rDRAMA",
+            "SERIALS\rACTION",
+        ]
+        # These should not be identified as series
+        invalid_test_cases = [
+            "SILENT FILM\rEDUCATIONAL\rNEWSREELS\rCARTOONS",
+            "FOO\rBAR\rBAZ",
+            "TELEVISION\rMINIATURE",
+        ]
+        self.valid_test_records = [
+            # recordId and modId are added
+            # for use in __repr__ method on Record class
+            Record(
+                keys=["recordId", "modId", "production_type"],
+                values=[index, 0, value],
+            )
+            for index, value in enumerate(valid_test_cases)
+        ]
+        self.invalid_test_records = [
+            Record(
+                keys=["recordId", "modId", "production_type"],
+                values=[index, 0, value],
+            )
+            for index, value in enumerate(invalid_test_cases)
+        ]
+
         for record in self.valid_test_records:
             with self.subTest(record=record):
                 self.assertTrue(is_series_production_type(record))

--- a/tests/test_metadata/test_marc.py
+++ b/tests/test_metadata/test_marc.py
@@ -141,7 +141,7 @@ class TestMarcTitlesRegion(TestCase):
 
     def test_spec_case_3(self):
         """Test the spec case where the main title and number of part are present,
-        but the name of part is not.
+        but the name of part is not, and Filemaker indicates that the record is a series.
         """
         record = self.minimal_bib_record
         record.add_field(
@@ -154,13 +154,36 @@ class TestMarcTitlesRegion(TestCase):
                 ],
             )
         )
-        titles = get_title_info(record)
+        titles = get_title_info(record, is_series=True)
+        expected_result = {
+            "title": "Main Title. Number of Part",
+            "series_title": "Main Title",
+            "episode_title": "Number of Part",
+        }
+        self.assertDictEqual(titles, expected_result)
+
+    def test_spec_case_4(self):
+        """Test the spec case where the main title and number of part are present,
+        but the name of part is not, and Filemaker indicates that the record is not a series.
+        """
+        record = self.minimal_bib_record
+        record.add_field(
+            Field(
+                tag="245",
+                indicators=Indicators("0", "0"),
+                subfields=[
+                    Subfield(code="a", value="Main Title"),
+                    Subfield(code="n", value="Number of Part"),
+                ],
+            )
+        )
+        titles = get_title_info(record, is_series=False)
         expected_result = {
             "title": "Main Title. Number of Part",
         }
         self.assertDictEqual(titles, expected_result)
 
-    def test_spec_case_4(self):
+    def test_spec_case_5(self):
         """Test the spec case where the main title is present,
         but the name of part and number of part are not.
         """


### PR DESCRIPTION
Implements [SYS-2043](https://uclalibrary.atlassian.net/browse/SYS-2043)

### Acceptance criteria
- [X] `get_title_info()` and supporting code in the `ftva_etl` package is updated with changes from the specs
    - [X] Use data from the Filemaker PD `production_type` field to help determine series / episode title information
- [X] `production_type` strings from Filemaker PD are normalized to allow comparison with list of series keywords

### Description
I updated the logic in the `get_title_info` function of the `marc.py` module to match the current [specs](https://uclalibrary.atlassian.net/wiki/spaces/pm/pages/1293385853/Legacy+ETL+1-1-1#DC-Element:-Title). A new case is added to account for the scenario where `245 $a` and $245 $n` are present in the MARC record, and the Filemaker PD record indicates the `production_type` is a series.

This later part is accomplished through the use of a new function in `filemaker.py` that checks whether any of the series keywords from the specs appear in the `production_type` data, after cleaning that data into a list, rather than a string with values delimited by carriage-returns. The cleanup is accomplished by a new utility function in `utils.py`.

### Testing
New tests are added, one to cover the new case in `get_title_info` and another to cover the `is_series_production_type` function in `filemaker.py`. There are now 15 total tests for the package.