### PR TITLE
DLSR-274: update default FM layout name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.3.1 - 2026-04-08
+
+### Changed
+- Updated the default Filemaker layout used by the Filemaker client.
+
 ## 0.3.0 - 2026-03-23
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.3.0"
+version = "0.3.1"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/clients/filemaker_client.py
+++ b/src/ftva_etl/clients/filemaker_client.py
@@ -14,7 +14,7 @@ class FilemakerClient:
         password: str,
         url: str = "https://adam.cinema.ucla.edu",
         database: str = "Inventory for Labeling",
-        layout: str = "InventoryForLabeling_ReadOnly_API",
+        layout: str = "InventoryForLabeling_API",
         api_version: str = "vLatest",
         timeout: int = 120,
     ) -> None:


### PR DESCRIPTION
Implements [DLSR-274](https://uclalibrary.atlassian.net/browse/DLSR-274)

A small change to update the default layout name used by the Filemaker client. Includes updated version number and changelog note.

[DLSR-274]: https://uclalibrary.atlassian.net/browse/DLSR-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ