### PR TITLE
DLSR-353: add find() methods to FM client (for range matching)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.3.2 - 2026-05-20
+
+### Added
+- New `FilemakerClient.find_all_records()` method for paginated retrieval of all records matching a query, supporting exact matches, ranges, and excluded values.
+
 ## 0.3.1 - 2026-04-08
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.3.1"
+version = "0.3.2"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/clients/filemaker_client.py
+++ b/src/ftva_etl/clients/filemaker_client.py
@@ -70,7 +70,9 @@ class FilemakerClient:
 
     def search_by_inventory_number(self, inventory_number: str) -> list[Record]:
 
-        records = self._find(query=[{"inventory_no": f"=={inventory_number}"}])
+        records = self._search_filemaker(
+            index="inventory_no", search_term=inventory_number
+        )
         return records
 
     def get_fields(
@@ -236,7 +238,7 @@ class FilemakerClient:
             # rather than simply returning an empty `Foundset`-- hence the `try` block.
             # Also the date format in `find()` defaults to US format (MM-DD-YYYY);
             # set it to ISO-8601 (YYYY-MM-DD) instead.
-            foundset = self._find(query, date_format="iso-8601")
+            foundset = self._fms.find(query, date_format="iso-8601")
             # Return list to be consistent with empty list returned if no records found.
             return list(foundset)
         except FileMakerError as error:

--- a/src/ftva_etl/clients/filemaker_client.py
+++ b/src/ftva_etl/clients/filemaker_client.py
@@ -70,9 +70,7 @@ class FilemakerClient:
 
     def search_by_inventory_number(self, inventory_number: str) -> list[Record]:
 
-        records = self._search_filemaker(
-            index="inventory_no", search_term=inventory_number
-        )
+        records = self._find(query=[{"inventory_no": f"=={inventory_number}"}])
         return records
 
     def get_fields(
@@ -134,6 +132,75 @@ class FilemakerClient:
                 return []  # return empty list if offset is out of bounds
             raise  # re-raise the error if it's something other than 101
 
+    def _find(self, query: list[dict], **kwargs) -> list[Record]:
+        """Convenience wrapper around `_fms.find()`.
+
+        Executes a FileMaker Data API find request using the provided query.
+        The query is a list of dicts, where each dict represents one find
+        request (criterion). Multiple dicts are OR-ed together by FileMaker.
+
+        Field values support FileMaker find operators, e.g.:
+        - Exact match: ``{"inventory_no": "==M1234"}``
+        - Range: ``{"date_modified": "05/01/2026...05/13/2026"}``
+        - Omit: ``{"omit": "true", "inventory_no": "==M1234"}``
+
+        NOTE: The FileMaker Data API returns at most 100 records by default.
+        Use `find_all_records()` instead to retrieve all matching records,
+        or pass `limit` and `offset` via kwargs to paginate manually.
+
+        :param list[dict] query: A list of find-criterion dicts.
+            See the FileMaker Data API documentation for full syntax.
+        :param kwargs: Additional arguments to pass to `_fms.find()`,
+            such as ``sort``, ``limit``, ``offset``, or ``date_format``.
+            See docs for `fmrest.Server.find()` for usage details.
+        :return: A list of matching Filemaker records (may be empty).
+        :raises FileMakerError: If an unknown error occurs while executing the find.
+        """
+        # Use try/except because `find()` raises exception (error 401) when no records match,
+        # rather than returning an empty result.
+        try:
+            fm_find_results = self._fms.find(query, **kwargs)
+            return list(fm_find_results)
+        except FileMakerError as error:
+            # Error 401 represents "No records found".
+            if "error 401" in error.args[0]:
+                return []  # return empty list if no records found
+            raise  # re-raise the error if it's something other than 401
+
+    def find_all_records(
+        self,
+        query: list[dict],
+        page_size: int = 5000,
+        **kwargs,
+    ) -> list[Record]:
+        """Execute a paginated FileMaker find query and return all matching records.
+
+        Calls `_find()` repeatedly with increasing offsets until all matching
+        records have been retrieved. This is necessary because the FileMaker
+        Data API returns at most 100 records per request by default.
+
+        :param list[dict] query: A FileMaker find query (list of criterion dicts).
+            See `_find()` for syntax details.
+        :param int page_size: Number of records to fetch per request. Default: 5000.
+        :param kwargs: Additional arguments to pass to each `_find()` call,
+            such as `sort` or `date_format`.
+        :return: List of all matching Records across all pages.
+        """
+        all_records = []
+        offset = 1
+
+        while True:
+            batch = self._find(query, offset=offset, limit=page_size, **kwargs)
+            if not batch:
+                break
+            all_records.extend(batch)
+            if len(batch) < page_size:
+                # Received a partial page, so this was the last one.
+                break
+            offset += page_size
+
+        return all_records
+
     def edit_record(self, record_id: int, field_data: dict, **kwargs) -> bool:
         """Convenience wrapper around `_fms.edit_record()`.
 
@@ -169,7 +236,7 @@ class FilemakerClient:
             # rather than simply returning an empty `Foundset`-- hence the `try` block.
             # Also the date format in `find()` defaults to US format (MM-DD-YYYY);
             # set it to ISO-8601 (YYYY-MM-DD) instead.
-            foundset = self._fms.find(query, date_format="iso-8601")
+            foundset = self._find(query, date_format="iso-8601")
             # Return list to be consistent with empty list returned if no records found.
             return list(foundset)
         except FileMakerError as error:


### PR DESCRIPTION
Implements [DLSR-353](https://uclalibrary.atlassian.net/browse/DLSR-353)

Adds two new methods to FilemakerClient:

- `_find()` — a wrapper around _fms.find() with 401 error handling
- `find_all_records()` — a paginated wrapper that calls _find() repeatedly until all matching records are retrieved

This is especially useful for using Filemaker's range-based finding. This will be used in the [validation audit report](https://uclalibrary.atlassian.net/browse/DLSR-329) to identify recently modified records. 

Usage examples:
```
from ftva_etl import FilemakerClient

# authenticate as usual
client = FilemakerClient(user="...", password="...", layout...)

# finds 464 records
records_modified_this_week = client.find_all_records([{"date_modified": "05/13/2026...05/20/2026"}])

# finds 107 records
records_modified_yesterday = client.find_all_records([{"date_modified": "=05/19/2026"}])

# times out, but probably isn't needed
records_modified_this_year = client.find_all_records([{"date_modified": "01/01/2026...05/20/2026"}])
```

[DLSR-353]: https://uclalibrary.atlassian.net/browse/DLSR-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ