### PR TITLE
DLSR-369: Add click dependency for spacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.3.3 - 2026-06-04
+
+### Fixed
+- Added `click` as an explicit dependency due to a [bug](https://github.com/explosion/spaCy/issues/13971) with `spacy`
+
 ## 0.3.2 - 2026-05-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.3.2"
+version = "0.3.3"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -25,6 +25,8 @@ dependencies = [
     'python-fmrest==1.7.5',
     'requests==2.32.4',
     'spacy==3.8.7',
+    # Add click due to spacy bug: https://github.com/explosion/spaCy/issues/13971
+    'click==8.2.1',
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@ requests==2.32.4
 pymarc==5.3.1
 # For NLP
 spacy==3.8.7
+# Add click due to spacy bug: https://github.com/explosion/spaCy/issues/13971
+click==8.2.1
+
 # Latest matching en_core_web_md (medium) model to match spacy 3.8.7
 en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl
 # For Filemaker API access


### PR DESCRIPTION
Fixes [DLSR-369](https://uclalibrary.atlassian.net/browse/DLSR-369). Version bump to `0.3.3`.

This fixes a [dependency bug](https://github.com/explosion/spaCy/issues/13971) caused by changes in a dependency of the `spacy` package we use.  We use version 3.8.7 of `spacy`, but the problem exists through the current `spacy` version 3.8.14.  Since I don't know what has changed in `spacy` and upgrading that doesn't help, I've left it as-is.

Explicitly adding the `click` dependency allows our package to build and all tests pass.

To test, do a full clean build and confirm tests still pass.


[DLSR-369]: https://uclalibrary.atlassian.net/browse/DLSR-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ