### PR TITLE
DLSR-372: Update copyright date key in MARC handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.3.4 - 2026-06-10
+
+### Changed
+- Updated key from `copyright_release_date` to `copyright_date` for date output in `marc.py` module.
+
 ## 0.3.3 - 2026-06-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.3.3"
+version = "0.3.4"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/metadata/marc.py
+++ b/src/ftva_etl/metadata/marc.py
@@ -55,14 +55,14 @@ def _get_date_from_bib(bib_record: Record) -> dict:
         # Now, check second indicators in order of preference:
         # 2 = distribution date
         # 1 = publication date (write as release_broadcast_date)
-        # 4 = copyright notice date
+        # 4 = copyright notice date (write as copyright_date)
         # 0 = production date
         # 3 = manufacture date
         indicator_priority = ["2", "1", "4", "0", "3"]
         qualifier_map = {
             "2": "distribution_date",
             "1": "release_broadcast_date",
-            "4": "copyright_notice_date",
+            "4": "copyright_date",
             "0": "production_date",
             "3": "manufacture_date",
         }

--- a/tests/test_metadata/test_marc.py
+++ b/tests/test_metadata/test_marc.py
@@ -380,32 +380,40 @@ class TestMarcDatesRegion(TestCase):
         self.assertDictEqual(date_info, expected_result)
 
     def test_date_264_indicator_priority(self):
-        record = self.minimal_bib_record
-        # Add a 264 field with second indicator 2 (highest priority)
-        record.add_field(
-            Field(
-                tag="264",
-                indicators=Indicators(" ", "2"),
-                subfields=[
-                    Subfield(code="c", value="2023"),
-                ],
-            )
-        )
-        # Add a 264 with second indicator 1 (lower priority)
-        record.add_field(
-            Field(
-                tag="264",
-                indicators=Indicators(" ", "1"),
-                subfields=[
-                    Subfield(code="c", value="2022"),
-                ],
-            )
-        )
-        date_info = get_date_info(record)
-        expected_result = {
-            "distribution_date": "2023",
+        # When multiple 264 $c fields are present,
+        # prioritize value of second indicator as follows: 2 > 1 > 4 > 0 > 3.
+        # Test cases are tuples of lists of 2nd indicators to use in each case,
+        # and the expected result from that list.
+        test_cases = [
+            (["2", "1", "4", "0", "3"], {"distribution_date": "2023"}),
+            (["1", "4", "0", "3"], {"release_broadcast_date": "2021"}),
+            (["4", "0", "3"], {"copyright_date": "2019"}),
+            (["0", "3"], {"production_date": "2017"}),
+            (["3"], {"manufacture_date": "2015"}),
+        ]
+        # Used to build the test records for each sub-test.
+        test_values = {
+            "2": "2023",
+            "1": "2021",
+            "4": "2019",
+            "0": "2017",
+            "3": "2015",
         }
-        self.assertDictEqual(date_info, expected_result)
+
+        for indicators, expected in test_cases:
+            with self.subTest(indicators=indicators):
+                record = _get_minimal_bib_record()
+                for indicator in indicators:
+                    record.add_field(
+                        Field(
+                            tag="264",
+                            indicators=Indicators(" ", indicator),
+                            subfields=[
+                                Subfield(code="c", value=test_values[indicator]),
+                            ],
+                        )
+                    )
+                self.assertDictEqual(get_date_info(record), expected)
 
     def test_date_formatting(self):
         record = self.minimal_bib_record


### PR DESCRIPTION
Implements [DLSR-372](https://uclalibrary.atlassian.net/browse/DLSR-372)

### Acceptance criteria
- [X] Change current `copyright_release_date` label to `copyright_date`
- [X] Review specs (Date sections 5.1 and 5.2) and confirm the other date programming logic is correct, making changes if needed per the specs.

### Description
This PR adjusts the `marc.py` module to output `copyright_date` instead of `copyright_release_date` for MARC records with a value of `4` in the second indicator on field `264 $c`. I reviewed the revisions to the specs vis-a-vis this change, and everything looks correct to me.

### Testing
I refactored the unit test related to prioritization of MARC dates to cover all cases, from records with every 2nd indicator qualifier to those with just one.

There are now 37 unit tests for the package, all passing.

[DLSR-372]: https://uclalibrary.atlassian.net/browse/DLSR-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ