### PR TITLE
DLSR-381: Add wrapper for `get_records` endpoint on Digital Data app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.4.0 - 2026-06-16
+
+### Added
+- New `DigitalDataClient.get_records()` method for paginated retrieval of FTVA Digital Data records, with optional query and field filtering.
+
 ## 0.3.4 - 2026-06-10
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.3.4"
+version = "0.4.0"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/clients/digital_data_client.py
+++ b/src/ftva_etl/clients/digital_data_client.py
@@ -39,9 +39,9 @@ class DigitalDataClient:
         url = f"{self._url}/records/"
         params: dict[str, int | str] = {}
         # All params are optional, so set them only if they are provided.
-        if offset:
+        if offset is not None:
             params["offset"] = offset
-        if limit:
+        if limit is not None:
             params["limit"] = limit
         if query:
             params["query"] = query

--- a/src/ftva_etl/clients/digital_data_client.py
+++ b/src/ftva_etl/clients/digital_data_client.py
@@ -16,7 +16,8 @@ class DigitalDataClient:
         """Get the FTVA Digital Data record matching the input record id.
 
         :param record_id: FTVA Digital Data record id.
-        :return: All of the record's data.
+        :return: Dict containing all of the record's data.
+        :raises HTTPError: If response status code is 400-599.
         """
         url = f"{self._url}/records/{record_id}"
         return self._get_record(url)
@@ -34,7 +35,8 @@ class DigitalDataClient:
         :param limit: Number of results to return. Default is 100, applied by the API.
         :param query: Optional search/filter string.
         :param fields: Optional list of fields to search in.
-        :return: JSON from the response, containing records and total_records.
+        :return: Dict containing `records` list and `total_records` count.
+        :raises HTTPError: If response status code is 400-599.
         """
         url = f"{self._url}/records/"
         params: dict[str, int | str] = {}
@@ -51,13 +53,21 @@ class DigitalDataClient:
 
         response = requests.get(url, auth=(self._user, self._password), params=params)
         response.raise_for_status()
-        return response.json()
+        if response.status_code == 200:
+            return response.json()
+        else:
+            # NOTE: Fallback response format is hard-coded here,
+            # in case the response status is unexpected,
+            # i.e. not 200 and not 400-599.
+            # Will need to update the format if the API changes.
+            return {"records": [], "total_records": 0}
 
     def _get_record(self, url: str) -> dict:
         """General routine for fetching data.
 
         :param url: The fully formed URL for the request.
-        :return: JSON from the response, containing all of the record's data.
+        :return: Dict containing all of the record's data.
+        :raises HTTPError: If response status code is 400-599.
         """
         # Very simple for now, matching the minimal REST API provided by
         # the FTVA Django application it calls.

--- a/src/ftva_etl/clients/digital_data_client.py
+++ b/src/ftva_etl/clients/digital_data_client.py
@@ -30,8 +30,8 @@ class DigitalDataClient:
     ) -> dict:
         """Get FTVA Digital Data records with optional filtering and pagination.
 
-        :param offset: Starting record for pagination. Defaults are applied by the API.
-        :param limit: Number of results to return. Defaults are applied by the API.
+        :param offset: Starting record for pagination. Default is 0, applied by the API.
+        :param limit: Number of results to return. Default is 100, applied by the API.
         :param query: Optional search/filter string.
         :param fields: Optional list of fields to search in.
         :return: JSON from the response, containing records and total_records.

--- a/src/ftva_etl/clients/digital_data_client.py
+++ b/src/ftva_etl/clients/digital_data_client.py
@@ -21,6 +21,38 @@ class DigitalDataClient:
         url = f"{self._url}/records/{record_id}"
         return self._get_record(url)
 
+    def get_records(
+        self,
+        offset: int | None = None,
+        limit: int | None = None,
+        query: str = "",
+        fields: list[str] | None = None,
+    ) -> dict:
+        """Get FTVA Digital Data records with optional filtering and pagination.
+
+        :param offset: Starting record for pagination. Defaults are applied by the API.
+        :param limit: Number of results to return. Defaults are applied by the API.
+        :param query: Optional search/filter string.
+        :param fields: Optional list of fields to search in.
+        :return: JSON from the response, containing records and total_records.
+        """
+        url = f"{self._url}/records/"
+        params: dict[str, int | str] = {}
+        # All params are optional, so set them only if they are provided.
+        if offset:
+            params["offset"] = offset
+        if limit:
+            params["limit"] = limit
+        if query:
+            params["query"] = query
+        # Fields expected as a comma-separated string.
+        if fields:
+            params["fields"] = ",".join(fields)
+
+        response = requests.get(url, auth=(self._user, self._password), params=params)
+        response.raise_for_status()
+        return response.json()
+
     def _get_record(self, url: str) -> dict:
         """General routine for fetching data.
 


### PR DESCRIPTION
Implements [DLSR-381](https://uclalibrary.atlassian.net/browse/DLSR-381)

### Acceptance criteria
- [X] A method is added to `ftva_etl.DigitalDataClient` that allows filtered sets of records to be retrieved from the Digital Data app, provided a query string and target field name(s)

### Description
Adds a wrapper for the refactored `get_records` endpoint on the Digital Data app, that now allows for filtering, in addition to the preexisting pagination. All parameters are optional on the wrapper.

### Testing
No automated unit tests are added, to avoid mocking the Digital Data API. To manually test, please verify basic wrapper functionality in a Python REPL or scratch script, e.g.:

```python
from src.ftva_etl.clients.digital_data_client import DigitalDataClient

dd_user = {{YOUR_USER}}
dd_pass = {{YOUR_PW}}
dd_url = "https://digital-data.cinema.ucla.edu/"

dd_client = DigitalDataClient(user=dd_user, password=dd_pass, url=dd_url)

records = dd_client.get_records(offset=0, limit=100)

assert len(records["records"]) == 100
```

[DLSR-381]: https://uclalibrary.atlassian.net/browse/DLSR-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ