### PR TITLE
DLSR-414: Refactor `mams_metadata.py` and handling of `record_type`, `match_asset`, and `file_type` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.5.0 - 2026-06-24
+
+### Changed
+- Refactored `mams_metadata.py` for clarity and to integrate metadata-formatting logic previously handled in external script.
+
 ## 0.4.0 - 2026-06-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.4.0"
+version = "0.5.0"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -37,7 +37,7 @@ def get_dcp_info(dd_record: dict) -> dict:
     :param dd_record: A Digital Data record
     :return: A dictionary of fields.
     """
-    if dd_record.get("file_type") != "DCP":
+    if dd_record.get("file_type", "") != "DCP":
         return {}
     return {
         # File name must always be empty for DCPs.
@@ -54,7 +54,7 @@ def get_dpx_info(dd_record: dict) -> dict:
     :param dd_record: A Digital Data record
     :return: A dictionary of fields.
     """
-    if dd_record.get("file_type") != "DPX":
+    if dd_record.get("file_type", "") != "DPX":
         return {}
     return {
         # File name must always be empty for DPXs.

--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -37,11 +37,14 @@ def get_dcp_info(dd_record: dict) -> dict:
     :param dd_record: A Digital Data record
     :return: A dictionary of fields.
     """
+    if dd_record.get("file_type") != "DCP":
+        return {}
     return {
         # File name must always be empty for DCPs.
         "file_name": "",
         "folder_name": get_folder_name(dd_record),
         "sub_folder_name": get_sub_folder_name(dd_record),
+        "file_type": "DCP",  # file type required by MAMS for DCP files
     }
 
 
@@ -51,11 +54,13 @@ def get_dpx_info(dd_record: dict) -> dict:
     :param dd_record: A Digital Data record
     :return: A dictionary of fields.
     """
+    if dd_record.get("file_type") != "DPX":
+        return {}
     return {
         # File name must always be empty for DPXs.
         "file_name": "",
         "folder_name": get_folder_name(dd_record),
-        "file_type": "DPX",  # Required by MAMS only for DPX files. Hard-coded here.
+        "file_type": "DPX",  # file type required by MAMS for DPX files
     }
 
 

--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -66,3 +66,34 @@ def get_audio_class(dd_record: dict) -> str:
     :return: The audio class, or an empty string if not present.
     """
     return dd_record.get("audio_class", "")
+
+
+def get_record_type_and_match_asset(dd_record: dict) -> dict:
+    """Return the record type for a Digital Data record,
+    and if applicable, the match asset for tracks.
+
+    :param dd_record: A Digital Data record
+    :return: A dictionary containing the record type,
+    and if applicable, the match asset for tracks.
+    """
+    # Check if the DD record is a track,
+    # indicated by an incoming relationship with a type of `isTrackOf`
+    incoming_relationships = dd_record.get("incoming_relationships", [])
+    # Get the first relationship with a type of `isTrackOf`,
+    # or None if no such relationship is found.
+    track_relationship = next(
+        (
+            relationship
+            for relationship in incoming_relationships
+            if relationship.get("relationship_type", "") == "isTrackOf"
+        ),
+        None,
+    )
+    # If a track relationship is found, set `record_type=track`
+    # and `match_asset` to the source UUID for the relationship.
+    if track_relationship:
+        return {
+            "record_type": "track",
+            "match_asset": track_relationship.get("source_uuid"),
+        }
+    return {"record_type": "asset"}

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -82,7 +82,7 @@ def get_filemaker_metadata(filemaker_record: FM_Record, is_series: bool) -> dict
     }
 
 
-def _extract_descriptive_metadata(source_metadata: dict) -> dict:
+def _get_descriptive_metadata(source_metadata: dict) -> dict:
     """Utility for extracting descriptive metadata fields from the provided source,
     i.e. `creators`, `language`, and all title and date fields.
     Since these fields are common to both Alma and Filemaker sources,
@@ -147,7 +147,7 @@ def get_mams_metadata(
     filemaker_fields = {
         "inventory_id": filemaker_metadata.get("inventory_id", ""),
         "inventory_numbers": filemaker_metadata.get("inventory_numbers", []),
-        **_extract_descriptive_metadata(filemaker_metadata),
+        **_get_descriptive_metadata(filemaker_metadata),
     }
 
     # Combine fields from Digital Data and Filemaker into a single metadata object...
@@ -160,7 +160,7 @@ def get_mams_metadata(
     if alma_metadata:
         alma_fields = {
             "alma_bib_id": alma_metadata.get("alma_bib_id", ""),
-            **_extract_descriptive_metadata(alma_metadata),
+            **_get_descriptive_metadata(alma_metadata),
         }
         metadata.update(alma_fields)
 

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -13,6 +13,7 @@ from .digital_data import (
     get_media_type,
     get_uuid,
     get_audio_class,
+    get_record_type_and_match_asset,
 )
 from .filemaker import (
     get_inventory_id,
@@ -81,30 +82,47 @@ def get_filemaker_metadata(filemaker_record: FM_Record, is_series: bool) -> dict
     }
 
 
-def _get_source_metadata(
+def _extract_descriptive_metadata(source_metadata: dict) -> dict:
+    """Utility for extracting descriptive metadata fields from the provided source,
+    i.e. `creators`, `language`, and all title and date fields.
+    Since these fields are common to both Alma and Filemaker sources,
+    and Alma is preferred as a source when present, but is not required,
+    this function is a reusable utility for extracting these fields from either source.
+
+    :param source_metadata: A dict containing source metadata (i.e. either from Filemaker or Alma).
+    :return: A dict containing descriptive metadata fields from the source metadata.
+    """
+    output = {
+        "creators": source_metadata.get("creators", []),
+        "language": source_metadata.get("language", ""),
+        **{k: v for k, v in source_metadata.items() if "title" in k},
+        **{k: v for k, v in source_metadata.items() if "date" in k},
+    }
+    return output
+
+
+def get_mams_metadata(
     digital_data_record: dict,
     filemaker_record: FM_Record,
     bib_record: Optional[Pymarc_Record] = None,
-    match_asset_uuid: Optional[str] = None,
+    nlp_model: Optional[Language] = None,
 ) -> dict:
-    """Retrieve and combine metadata from the source records into a single dict, for
-    further processing and eventual output to the MAMS.
+    """Format the source metadata for output to the MAMS.
 
     :param digital_data_record: A dict containing an FTVA digital data record.
     :param filemaker_record: A fmrest filemaker record.
     :param bib_record: A pymarc record, expected to contain bibliographic data.
         Optional to support multiple types of matching (e.g. DD-FM-Alma or DD-FM only).
-    :param match_asset_uuid: A string representation of an asset's UUID. Defaults to None.
-    :return asset: A dict of metadata combined from the input records.
+    :param nlp_model: A spacy language model to use for NER.
+        If not provided, the default spacy model (en_core_web_md) will be used.
+    :return: A dict containing the metadata formatted for output to the MAMS.
     """
+    # Allow caller to provide the spacy model, to avoid loading it on every call
+    if not nlp_model:
+        nlp_model = spacy.load("en_core_web_md")
 
-    # Load spacy model for NER
-    # TODO: Support use of a custom model, if needed?
-    # Not sure yet where this should be loaded, or what performance impact
-    # may be for batch processing.
-    nlp_model = spacy.load("en_core_web_md")
-
-    # Determine if the record is a series, as determined by the Filemaker record.
+    # Used by both Filemaker and Alma metadata functions for determining how to format title info.
+    # Filemaker is the source-of-truth for whether something is a series.
     is_series = is_series_production_type(filemaker_record)
 
     filemaker_metadata = get_filemaker_metadata(filemaker_record, is_series)
@@ -113,96 +131,37 @@ def _get_source_metadata(
         get_alma_metadata(bib_record, nlp_model, is_series) if bib_record else {}
     )
 
-    # Get the rest of the data and prepare it for return.
-    metadata = {
-        "alma": alma_metadata,
-        "filemaker": filemaker_metadata,
+    # These are all the fields derived from the Digital Data app
+    digital_data_fields = {
         "uuid": get_uuid(digital_data_record),
         "file_name": get_file_name(digital_data_record),
         "asset_type": get_asset_type(digital_data_record),
         "media_type": get_media_type(digital_data_record),
         "audio_class": get_audio_class(digital_data_record),
+        **get_record_type_and_match_asset(digital_data_record),
+        **get_dcp_info(digital_data_record),  # returns DCP fields if file type is DCP
+        **get_dpx_info(digital_data_record),  # returns DPX fields if file type is DPX
     }
 
-    # If a match_asset_uuid is provided for a track, add it to the metadata record.
-    if match_asset_uuid:
-        metadata["match_asset"] = match_asset_uuid
+    # These are the fields from Filemaker
+    filemaker_fields = {
+        "inventory_id": filemaker_metadata.get("inventory_id", ""),
+        "inventory_numbers": filemaker_metadata.get("inventory_numbers", []),
+        **_extract_descriptive_metadata(filemaker_metadata),
+    }
 
-    # Override some elements based on file type.
-    file_type = digital_data_record.get("file_type", "")
-    if file_type == "DCP":
-        metadata.update(get_dcp_info(digital_data_record))
-    elif file_type == "DPX":
-        metadata.update(get_dpx_info(digital_data_record))
-    else:
-        # No special action needed
-        pass
-
-    return metadata
-
-
-def _extract_source_metadata(source_metadata: dict, type: str) -> dict:
-    """Extract the relevant metadata for a given type (e.g. alma, filemaker) from the
-    combined source metadata dict.
-
-    :param source_metadata: A dict containing the combined source metadata.
-    :param type: The type of metadata to extract (e.g. "alma", "filemaker").
-    :return: A dict containing unpacked metadata for the given type.
-    """
-    output = {}
-    output["creators"] = source_metadata[type].get("creators", [])
-    output["language"] = source_metadata[type].get("language", "")
-    # Get all fields with "title" in the name (e.g. title, series_title).
-    output.update({k: v for k, v in source_metadata[type].items() if "title" in k})
-    # Get all date fields (e.g. release_broadcast_date, distribution_date).
-    output.update({k: v for k, v in source_metadata[type].items() if "date" in k})
-    return output
-
-
-def get_mams_metadata(
-    digital_data_record: dict,
-    filemaker_record: FM_Record,
-    bib_record: Optional[Pymarc_Record] = None,
-    match_asset_uuid: Optional[str] = None,
-) -> dict:
-    """Format the source metadata for output to the MAMS.
-
-    :param digital_data_record: A dict containing an FTVA digital data record.
-    :param filemaker_record: A fmrest filemaker record.
-    :param bib_record: A pymarc record, expected to contain bibliographic data.
-        Optional to support multiple types of matching (e.g. DD-FM-Alma or DD-FM only).
-    :param match_asset_uuid: A string representation of an asset's UUID. Defaults to None.
-    :return: A dict containing the metadata formatted for output to the MAMS.
-    """
-    source_metadata = _get_source_metadata(
-        digital_data_record, filemaker_record, bib_record, match_asset_uuid
-    )
-    # Begin structuring metadata for MAMS output.
-    # For now, always assume we have a Filemaker record.
+    # Combine fields from Digital Data and Filemaker into a single metadata object...
     metadata = {
-        "inventory_id": source_metadata["filemaker"]["inventory_id"],
-        "uuid": source_metadata["uuid"],
-        "inventory_numbers": source_metadata["filemaker"]["inventory_numbers"],
-        "file_name": source_metadata["file_name"],
-        "asset_type": source_metadata["asset_type"],
-        "media_type": source_metadata["media_type"],
-        "audio_class": source_metadata["audio_class"],
+        **digital_data_fields,
+        **filemaker_fields,
     }
-    # Folder and subfolder may be empty, depending on file type.
-    # Match Asset may also be empty depending on asset/track relationships and matching results.
-    # Only include if there is a value.
-    if source_metadata.get("folder_name"):
-        metadata["folder_name"] = source_metadata["folder_name"]
-    if source_metadata.get("sub_folder_name"):
-        metadata["sub_folder_name"] = source_metadata["sub_folder_name"]
-    if source_metadata.get("match_asset"):
-        metadata["match_asset"] = source_metadata["match_asset"]
 
-    # 1-1-1 match: if we have Alma metadata, it is preferred over FM for certain fields.
-    if source_metadata.get("alma"):
-        metadata["alma_bib_id"] = source_metadata["alma"].get("alma_bib_id", "")
-        metadata.update(_extract_source_metadata(source_metadata, "alma"))
-    else:
-        metadata.update(_extract_source_metadata(source_metadata, "filemaker"))
+    # ...and if Alma metadata is available, update the metadata dict with Alma fields
+    if alma_metadata:
+        alma_fields = {
+            "alma_bib_id": alma_metadata.get("alma_bib_id", ""),
+            **_extract_descriptive_metadata(alma_metadata),
+        }
+        metadata.update(alma_fields)
 
     return metadata

--- a/tests/test_metadata/test_digital_data.py
+++ b/tests/test_metadata/test_digital_data.py
@@ -1,5 +1,9 @@
 from unittest import TestCase
-from src.ftva_etl.metadata.digital_data import get_dcp_info, get_dpx_info
+from src.ftva_etl.metadata.digital_data import (
+    get_dcp_info,
+    get_dpx_info,
+    get_record_type_and_match_asset,
+)
 
 
 class TestDigitalData(TestCase):
@@ -19,8 +23,8 @@ class TestDigitalData(TestCase):
         # Note that these methods may rename some field names, which is intentional.
         self.assertEqual(dcp_info["folder_name"], "folder name")
         self.assertEqual(dcp_info["sub_folder_name"], "sub folder name")
-        # `file_type` should not be present
-        self.assertNotIn("file_type", dcp_info)
+        # `file_type` should be "DCP"
+        self.assertEqual(dcp_info["file_type"], "DCP")
 
     def test_dpx_info(self):
         # Very simple Digital Data record for DPX.
@@ -39,5 +43,72 @@ class TestDigitalData(TestCase):
         self.assertEqual(dpx_info["folder_name"], "folder name")
         # For DPX, do not include subfolders.
         self.assertNotIn("sub_folder_name", dpx_info)
-        # For DPX only, `file_type` should be "DPX"
+        # `file_type` should be "DPX"
         self.assertEqual(dpx_info["file_type"], "DPX")
+
+    def test_get_record_type_and_match_asset(self):
+        """Test the get_record_type_and_match_asset function."""
+        test_digital_data_records = [
+            {
+                "uuid": "12345",
+                "inventory_numbers": ["INV001"],
+            },  # Record 1: no track relationship indicated in DD record
+            {
+                "uuid": "67890",
+                "inventory_numbers": ["INV002"],
+                "incoming_relationships": [
+                    {
+                        "relationship_type": "isTrackOf",
+                        "source_uuid": "12345",
+                    }
+                ],
+            },  # Record 2: track relationship indicated in DD record targeting asset 12345
+            {
+                "uuid": "78901",
+                "inventory_numbers": ["INV003"],
+                "incoming_relationships": [
+                    {
+                        "relationship_type": "isPartOf",
+                        "source_uuid": "12345",
+                    }
+                ],
+            },  # Record 3: wrong relationship type indicated in DD record targeting asset 12345
+            {
+                "uuid": "12345",
+                "inventory_numbers": ["INV004"],
+                "incoming_relationships": [
+                    {
+                        "relationship_type": "isTrackOf",
+                        "source_uuid": "78901",
+                    },
+                    {
+                        "relationship_type": "isTrackOf",
+                        "source_uuid": "67890",
+                    },
+                ],
+            },  # Record 4: multiple track relationships indicated in DD record
+        ]
+        expected_results = [
+            {
+                "record_type": "asset",
+            },  # Record 1 should be an asset
+            {
+                "record_type": "track",
+                "match_asset": "12345",
+            },  # Record 2 should be a track, with match_asset set to UUID of the asset
+            {
+                "record_type": "asset",
+            },  # Record 3 should be an asset
+            {
+                "record_type": "track",
+                "match_asset": "78901",
+            },  # Record 4 should be a track, with match_asset set from the first relationship
+        ]
+
+        # Zip together the two lists to get tuples of (dd_record, expected_result)
+        for dd_record, expected_result in zip(
+            test_digital_data_records, expected_results
+        ):
+            with self.subTest(dd_record=dd_record, expected_result=expected_result):
+                result = get_record_type_and_match_asset(dd_record)
+                self.assertEqual(result, expected_result)

--- a/tests/test_metadata/test_digital_data.py
+++ b/tests/test_metadata/test_digital_data.py
@@ -74,7 +74,7 @@ class TestDigitalData(TestCase):
                 ],
             },  # Record 3: wrong relationship type indicated in DD record targeting asset 12345
             {
-                "uuid": "12345",
+                "uuid": "98765",
                 "inventory_numbers": ["INV004"],
                 "incoming_relationships": [
                     {


### PR DESCRIPTION
Implements [DLSR-414](https://uclalibrary.atlassian.net/browse/DLSR-414)

### Acceptance criteria
- [X] The dict returned by `mams_metadata.get_mams_metadata()` includes a `record_type` property for all records, and a `match_asset` property for tracks
- [X] `file_type` is set correctly for DPX and DCP records in the metadata dict
- [X] Tests are updated as needed
- [x] Module is refactored for clarity


### Description
This PR brings in logic related to the `record_type`, `match_asset`, and `file_type` fields expected in the target JSON metadata, which are currently handled in the `ftva_mams_metadata.generate_metadata` script. The PR is also a broader refactor of the `mams_metadata` module, as the scope of the ticket morphed somewhat after getting started on bringing in the logic from `ftva_mams_metadata`.

The primary change is to collapse the main, public `get_mams_metadata` function with `_get_source_metadata`, which we had been using to format the metadata from Digital Data, Filemaker, and optionally Alma source records. I think combining the two functions makes the code clearer, though it does result in a messy diff...sorry about that. Please let me know if I can better clarify my rationale or any of the changes.

To my mind, the main goal with these changes is to improve the separation of concerns between `ftva-etl` and `ftva-mams-metadata`. I think the former should be responsible for formatting the authoritative metadata records (done in this PR), and the latter should only be concerned with batching the records, which includes validating that tracks point to asset records that are actually in the batch (to be done with the open ticket on `ftva-mams-metadata`).

### Testing
I added a unit test to cover the logic related to getting `record_type` and `match_asset` from Digital Data records. I also updated the unit tests related to `file_type` on DCP and DPX records. I believe the latest specs for the MAMS JSON expect `file_type` set for both DCP and DPX, whereas previously it was just DPX.

There should be 38 total tests: `python -m unittest discover tests`

[DLSR-414]: https://uclalibrary.atlassian.net/browse/DLSR-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ