### PR TITLE
DLSR-410: Fix date parsing bug related to dates with only year and month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.5.1 - 2026-06-30
+
+### Changed
+- Fixed bug related to parsing of dates from MARC records with only year and month
+
 ## 0.5.0 - 2026-06-24
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.5.0"
+version = "0.5.1"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/metadata/utils.py
+++ b/src/ftva_etl/metadata/utils.py
@@ -23,10 +23,15 @@ def _is_imprecise_date(date_string: str) -> bool:
         "%B %Y",  # Month name, space, and year, e.g. "October 1996"
         "%b %Y",  # Month abbreviation, space, and year, e.g. "Oct 1996"
     )
-    # Special check for 4-digit year with possible hyphen indicating an uncertain year,
-    # needed because `%Y` would not handle hyphens
+    # Special check for 4-digit year with possible hyphen indicating an uncertain year.
+    # Year only could be checked with `%Y` above, but it would not handle hyphens.
+    # The check below returns True if:
+    # 1. date_string is just a year (i.e. 4 digits); or
+    # 2. date_string has a length of 4, and has hyphens to indicate an uncertain year,
+    #    e.g. "202-" or "19--".
     if len(date_string) == 4 and (date_string.isdigit() or "-" in date_string):
         return True
+
     for format in imprecise_date_formats:
         try:
             # `strptime` will raise a ValueError

--- a/src/ftva_etl/metadata/utils.py
+++ b/src/ftva_etl/metadata/utils.py
@@ -2,7 +2,43 @@ import sys
 import dateutil.parser
 import string
 import logging
+from datetime import datetime
 from typing import Optional
+
+# Create a module logger, which will be a child of the package logger
+logger = logging.getLogger(__name__)
+
+
+def _is_imprecise_date(date_string: str) -> bool:
+    """Return True if date_string lacks full year-month-day precision.
+
+    :param date_string: The date string to check.
+    :return: True if the date string is imprecise, False otherwise.
+    """
+    # These are date format strings that indicate an imprecise date
+    imprecise_date_formats = (
+        "%Y-%m",  # Year-month, e.g. "1996-10"
+        "%B, %Y",  # Month name, comma, and year, e.g. "October, 1996"
+        "%b. %Y",  # Month abbreviation, period, and year, e.g. "Oct. 1996"
+        "%B %Y",  # Month name, space, and year, e.g. "October 1996"
+        "%b %Y",  # Month abbreviation, space, and year, e.g. "Oct 1996"
+    )
+    # Special check for 4-digit year with possible hyphen indicating an uncertain year,
+    # needed because `%Y` would not handle hyphens
+    if len(date_string) == 4 and (date_string.isdigit() or "-" in date_string):
+        return True
+    for format in imprecise_date_formats:
+        try:
+            # `strptime` will raise a ValueError
+            # if the date string does not fully match the format.
+            # Using it here as a pattern-matcher, not a parser.
+            datetime.strptime(date_string, format)
+            # If we get here, the date string matches one of the formats,
+            # so it is imprecise and we return True.
+            return True
+        except ValueError:
+            continue
+    return False
 
 
 def parse_date(date_string: str) -> str:
@@ -21,26 +57,19 @@ def parse_date(date_string: str) -> str:
     date_string = date_string.rstrip(".,;:!?")
     date_string = date_string.strip()
 
-    # Keep date_string as is if it matches one of the following conditions:
-    # 1. date_string is just a year (i.e. 4 digits); or
-    # 2. date_string has a length of 4, and has hyphens to indicate an uncertain year
-    if len(date_string) == 4 and (date_string.isdigit() or "-" in date_string):
+    # If the date string is imprecise (i.e. not year-month-day precision), keep it as-is
+    if _is_imprecise_date(date_string):
         formatted_date = date_string
-        if in_brackets:
-            formatted_date = f"[{formatted_date}]"
-        return formatted_date
-
-    # Try to parse the date string using dateutil.parser
-    # TODO: Handle dates with only month and year?
-    try:
-        parsed_date = dateutil.parser.parse(date_string)
-        # Format the date as YYYY-MM-DD
-        formatted_date = parsed_date.strftime("%Y-%m-%d")
-    except (ValueError, dateutil.parser.ParserError):  # TODO: as e:
-        # If parsing fails, log the error and return the original string
-        # TODO: LOGGING
-        # logging.info(f"Failed to parse date '{date_string}': {e}")
-        formatted_date = date_string
+    # Otherwise, try to parse the date string, handling any unexpected errors.
+    else:
+        try:
+            parsed_date = dateutil.parser.parse(date_string)
+            # Format the date as YYYY-MM-DD
+            formatted_date = parsed_date.strftime("%Y-%m-%d")
+        except (ValueError, dateutil.parser.ParserError) as e:
+            # If parsing fails, log the error and return the original string.
+            logger.warning(f"Failed to parse date '{date_string}': {e}")
+            formatted_date = date_string
 
     if in_brackets:
         formatted_date = f"[{formatted_date}]"

--- a/tests/test_metadata/test_marc.py
+++ b/tests/test_metadata/test_marc.py
@@ -485,6 +485,34 @@ class TestMarcDatesRegion(TestCase):
         }
         self.assertDictEqual(date_info, expected_result)
 
+    def test_date_only_month_and_year(self):
+        """Test that dates with only month and year in various formats are parsed correctly."""
+
+        # Values with only month and year should remain unchanged
+        test_cases = [
+            "October 1996",  # Month name and year
+            "Oct 1996",  # Month abbreviation and year
+            "1996-10",  # Numeric year-month
+            "[October 1996]",  # Month name and year in brackets
+            "[Oct. 1996]",  # Month abbr, period, and year in brackets
+            "March, 1955",  # Month name, comma, and year
+            "MAR 1955",  # Capitalized month abbreviation and year
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case=test_case):
+                record = _get_minimal_bib_record()
+                record.add_field(
+                    Field(
+                        tag="260",
+                        indicators=Indicators(" ", " "),
+                        subfields=[Subfield(code="c", value=test_case)],
+                    )
+                )
+                date_info = get_date_info(record)
+                # Should be parsed as `release_broadcast_date` with value unchanged
+                self.assertDictEqual(date_info, {"release_broadcast_date": test_case})
+
 
 class TestMarcCreatorsRegion(TestCase):
     """Test the creators region of the MARC metadata module.


### PR DESCRIPTION
Fixes [DLSR-410](https://uclalibrary.atlassian.net/browse/DLSR-410)

### Bug description
- Dates extracted from MARC records with only year and month (e.g. `October 1996` or `1996-10`) were not parsing correctly, as the current day of the month was being added to them by the date parser utility

### Fix
- Adds a new helper function in the `metadata/utils.py` module to check if a date string is "imprecise", meaning it lacks year-month-day precision
- The core `parse_date` utility that handles date parsing and formatting now uses this new helper to handle dates with only year and month, with flexibility to add other imprecise date patterns later, as needed

### Testing
A new test for several sub-tests covering various year-month variations is added. Should now be 39 tests total, all passing: `python -m unittest discover tests`

[DLSR-410]: https://uclalibrary.atlassian.net/browse/DLSR-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ