### PR TITLE
DLSR-447: Add metadata generation module for NDM

### DIFF
--- a/src/ftva_etl/__init__.py
+++ b/src/ftva_etl/__init__.py
@@ -17,3 +17,4 @@ from .clients.digital_data_client import DigitalDataClient  # noqa
 
 # Metadata generator
 from .metadata.mams_metadata import get_mams_metadata  # noqa
+from .metadata.mams_metadata_ndm import get_mams_metadata_ndm  # noqa

--- a/src/ftva_etl/metadata/mams_metadata_ndm.py
+++ b/src/ftva_etl/metadata/mams_metadata_ndm.py
@@ -1,0 +1,148 @@
+import spacy
+import logging
+
+from fmrest.record import Record as FM_Record
+from pymarc import Record as Pymarc_Record
+from typing import Optional
+from spacy.language import Language
+from .filemaker import (
+    get_inventory_id,
+    get_inventory_number,
+    is_series_production_type,
+    get_creators as get_fm_creators,
+    get_date_info as get_fm_date_info,
+    get_language_name as get_fm_language_name,
+    get_title_info as get_fm_title_info,
+)
+from .marc import (
+    get_bib_id,
+    get_creators as get_alma_creators,
+    get_date_info as get_alma_date_info,
+    get_language_name as get_alma_language_name,
+    get_title_info as get_alma_title_info,
+)
+
+
+# Create a module logger, which will be a child of the package logger
+logger = logging.getLogger(__name__)
+
+
+def get_alma_metadata(
+    bib_record: Pymarc_Record, nlp_model: Language, is_series: bool = False
+) -> dict:
+    """Get the Alma metadata from a pymarc record.
+
+    :param bib_record: A pymarc record.
+    :param nlp_model: A spacy language model to use for NER.
+    :param is_series: Whether the record is a series, derived from Filemaker record.
+        Defaults to False.
+    :return: A dict containing the Alma metadata needed for the MAMS.
+    """
+    # This gets a collection of titles which will be unpacked later.
+    titles = get_alma_title_info(bib_record, is_series)
+    return {
+        "alma_bib_id": get_bib_id(bib_record),
+        "language": get_alma_language_name(bib_record),
+        "creators": get_alma_creators(bib_record, nlp_model),
+        **titles,
+        **get_alma_date_info(bib_record),
+    }
+
+
+def get_filemaker_metadata(filemaker_record: FM_Record, is_series: bool) -> dict:
+    """Get the Filemaker metadata from a Filemaker record.
+
+    :param filemaker_record: A Filemaker record.
+    :param is_series: Whether the record is a series, derived from Filemaker record.
+    :return: A dict containing the Filemaker metadata needed for the MAMS.
+    """
+    titles = get_fm_title_info(filemaker_record, is_series)
+    return {
+        "inventory_id": get_inventory_id(filemaker_record),
+        # All records returned from FM
+        # should have only one inventory number for now,
+        # but MAMS expects an array in JSON, so wrap in a list.
+        # TODO: Parse comma-separated or otherwise delimited inventory numbers
+        # from FM or other sources, if needed.
+        "inventory_numbers": [get_inventory_number(filemaker_record)],
+        "creators": get_fm_creators(filemaker_record),
+        "language": get_fm_language_name(filemaker_record),
+        **titles,
+        **get_fm_date_info(filemaker_record),
+    }
+
+
+def _get_descriptive_metadata(source_metadata: dict) -> dict:
+    """Utility for extracting descriptive metadata fields from the provided source,
+    i.e. `creators`, `language`, and all title and date fields.
+    Since these fields are common to both Alma and Filemaker sources,
+    and Alma is preferred as a source when present, but is not required,
+    this function is a reusable utility for extracting these fields from either source.
+
+    :param source_metadata: A dict containing source metadata (i.e. either from Filemaker or Alma).
+    :return: A dict containing descriptive metadata fields from the source metadata.
+    """
+    output = {
+        "creators": source_metadata.get("creators", []),
+        "language": source_metadata.get("language", ""),
+        **{k: v for k, v in source_metadata.items() if "title" in k},
+        **{k: v for k, v in source_metadata.items() if "date" in k},
+    }
+    return output
+
+
+def get_mams_metadata_ndm(
+    fm_item_record: FM_Record,
+    fm_inventory_record: FM_Record,
+    alma_bib_record: Optional[Pymarc_Record] = None,
+    match_asset: Optional[str] = None,
+    nlp_model: Optional[Language] = None,
+) -> dict:
+    """Format metadata for output to the MAMS using new digital media (NDM) metadata sources.
+
+    :param fm_item_record: A fmrest filemaker record containing item unit data.
+    :param fm_inventory_record: A fmrest filemaker record containing inventory data.
+    :param alma_bib_record: A pymarc record, expected to contain bibliographic data.
+        Optional to support multiple types of matching (e.g. FM-Alma or FM only).
+    :param match_asset: A string representation of the UUID for a related asset, if this is a track.
+    :param nlp_model: A spacy language model to use for NER.
+        If not provided, the default spacy model (en_core_web_md) will be used.
+    :return: A dict containing the metadata formatted for output to the MAMS.
+    """
+    # Allow caller to provide the spacy model, to avoid loading it on every call
+    if not nlp_model:
+        nlp_model = spacy.load("en_core_web_md")
+
+    # Used by both Filemaker and Alma metadata functions for determining how to format title info.
+    # Filemaker is the source-of-truth for whether something is a series.
+    is_series = is_series_production_type(fm_inventory_record)
+
+    filemaker_metadata = get_filemaker_metadata(fm_inventory_record, is_series)
+
+    alma_metadata = (
+        get_alma_metadata(alma_bib_record, nlp_model, is_series)
+        if alma_bib_record
+        else {}
+    )
+
+    # These are the fields from Filemaker
+    filemaker_fields = {
+        "inventory_id": filemaker_metadata.get("inventory_id", ""),
+        "inventory_numbers": filemaker_metadata.get("inventory_numbers", []),
+        **_get_descriptive_metadata(filemaker_metadata),
+    }
+
+    # Unpack fields from Filemaker into a single metadata object...
+    metadata = {
+        **filemaker_fields,
+    }
+
+    # ...and if Alma metadata is available, update the metadata dict with Alma fields
+    if alma_metadata:
+        alma_fields = {
+            "alma_bib_id": alma_metadata.get("alma_bib_id", ""),
+            **_get_descriptive_metadata(alma_metadata),
+        }
+        metadata.update(alma_fields)
+
+    return metadata


### PR DESCRIPTION
Implements [DLSR-447](https://uclalibrary.atlassian.net/browse/DLSR-447)

## Acceptance criteria
- [X] A new module is added that returns metadata records formatted for ingest into the MAMS, using new digital media (NDM) records originating in Filemaker as input
  - The new `get_mams_metadata_ndm()` public function does return a valid dict, but it is not fully aligned with the new NDM specs. This will be addressed in a separate ticket/PR.
- [X] Where possible, code is reused from metadata generation for legacy media
- [X] Functions and/or modules are renamed to clearly distinguish NDM from legacy metadata generation
- [X] Changes do not break existing consumers of `mams_metadata.py`

## Description
This PR adds a new module named `mams_metadata_ndm.py` to handle metadata generation for new digital media (NDM) sources. New logic from the NDM ETL specs is not implemented here; that will be addressed in a separate ticket and PR.

## Testing
No new unit tests are added. All 39 existing tests still pass: `python -m unittest discover tests`

To test that functionality of the `mams_metadata.py` module remains unchanged, the changes on this branch can be installed in the `ftva_mams_metadata` dev container. From within that container, run:

`pip install --force-reinstall --no-deps git+https://github.com/UCLALibrary/ftva-etl@DLSR-447/add-function-for-ndm`

Then re-run legacy batch 3c as an example using the legacy metadata generation script to confirm it matches earlier outputs: `python generate_metadata_legacy_media.py -c config_dev.toml -b 3c`. The only difference should be the one `release_broadcast_date` field, addressed in #36.

The new NDM metadata generation script can also be run: `python generate_metadata_new_media.py -c config_dev.toml -i PATH/TO/SPREADSHEET`. The program should complete successfully (i.e. it shouldn't crash), but the resulting metadata output won't be complete. The NDM batch 1 Google Sheet that Christina prepared can be used as an example input file. I can send it separately if need be; don't want to share it here, since it's a public link.

[DLSR-447]: https://uclalibrary.atlassian.net/browse/DLSR-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ