### PR TITLE
DLSR-448: Implement NDM logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.6.0 - 2026-07-14
+
+### Added
+- Added `mams_metadata_ndm.py` module for formatting NDM metadata
+
 ## 0.5.1 - 2026-06-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 - Added `mams_metadata_ndm.py` module for formatting NDM metadata
+- Implemented new logic per NDM specs
 
 ## 0.5.1 - 2026-06-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.5.1"
+version = "0.6.0"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -20,6 +20,16 @@ def get_inventory_id(fm_record: Record) -> str:
     return str(fm_record.inventory_id)
 
 
+def get_inventory_ids(fm_record: Record) -> list[str]:
+    """Get the inventory ids from a Filemaker record,
+    parsing comma-separated values into a list of strings.
+
+    :param fm_record: A Filemaker record.
+    :return: A list of inventory ids.
+    """
+    return [inventory_id.strip() for inventory_id in fm_record.inventory_id.split(",")]
+
+
 def get_inventory_number(fm_record: Record) -> str:
     """Get the inventory number from a Filemaker record.
 
@@ -27,6 +37,19 @@ def get_inventory_number(fm_record: Record) -> str:
     :return: The inventory number as a string.
     """
     return fm_record.inventory_no
+
+
+def get_inventory_numbers(fm_record: Record) -> list[str]:
+    """Get the inventory numbers from a Filemaker record,
+    parsing comma-separated values into a list of strings.
+
+    :param fm_record: A Filemaker record.
+    :return: A list of inventory numbers.
+    """
+    return [
+        inventory_number.strip()
+        for inventory_number in fm_record.inventory_number.split(",")
+    ]
 
 
 def is_series_production_type(fm_record: Record) -> bool:

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -27,7 +27,9 @@ def get_inventory_ids(fm_record: Record) -> list[str]:
     :param fm_record: A Filemaker record.
     :return: A list of inventory ids.
     """
-    return [inventory_id.strip() for inventory_id in fm_record.inventory_id.split(",")]
+    return [
+        inventory_id.strip() for inventory_id in str(fm_record.inventory_id).split(",")
+    ]
 
 
 def get_inventory_number(fm_record: Record) -> str:

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -48,7 +48,7 @@ def get_inventory_numbers(fm_record: Record) -> list[str]:
     """
     return [
         inventory_number.strip()
-        for inventory_number in fm_record.inventory_number.split(",")
+        for inventory_number in fm_record.inventory_no.split(",")
     ]
 
 

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -1,6 +1,8 @@
-from fmrest.record import Record
-from .utils import cleanup_production_type
 import logging
+
+from fmrest.record import Record
+from pathlib import PurePath
+from .utils import cleanup_production_type
 
 
 # Code which extracts data from a Filemaker record.
@@ -159,3 +161,93 @@ def get_title_info(fm_record: Record, is_series: bool) -> dict:
         }
     else:
         return {"title": fm_title}
+
+
+def get_source_id(fm_record: Record) -> str:
+    """Get the source identifier from a Filemaker record.
+
+    :param fm_record: A Filemaker record.
+    :return: The source identifier as a string.
+    """
+    return fm_record.source_identifier
+
+
+def get_uuid(fm_record: Record) -> str:
+    """Get the UUID from a Filemaker record.
+
+    :param fm_record: A Filemaker record.
+    :return: The UUID as a string.
+    """
+    return fm_record["UUID"]  # field name is capitalized in FM
+
+
+def get_creation_date(fm_record: Record) -> str:
+    """Get the creation date from a Filemaker record.
+
+    :param fm_record: A Filemaker record.
+    :return: The creation date as a string.
+    """
+    return fm_record["Creation_date"]  # note capitalization in field name
+
+
+def get_asset_type(fm_record: Record) -> str:
+    """Get the asset type from a Filemaker record.
+
+    :param fm_record: A Filemaker record.
+    :return: The asset type as a string.
+    """
+    return fm_record.asset_type
+
+
+def get_media_type(fm_record: Record) -> str:
+    """Get the media type from a Filemaker record.
+
+    :param fm_record: A Filemaker record.
+    :return: The media type as a string.
+    """
+    return fm_record.media_type
+
+
+def get_audio_class(fm_record: Record) -> str:
+    """Get the audio class from a Filemaker record.
+
+    :param fm_record: A Filemaker record.
+    :return: The audio class as a string.
+    """
+    # Specs say to return "Unknown" if this field is an empty string
+    return fm_record.audio_class if fm_record.audio_class.strip() != "" else "Unknown"
+
+
+def get_file_path_info(fm_record: Record) -> dict:
+    """Get the file path info from a Filemaker record.
+
+    :param fm_record: A Filemaker record.
+    :return: A dict containing the file path info.
+    """
+    raw_value = fm_record.file_path
+    try:
+        file_path = PurePath(raw_value)
+    except ValueError:
+        logger.warning(
+            f"Filemaker record with record ID {fm_record.recordId} "
+            f"has an invalid `file_path` value: {raw_value}"
+        )
+        return {}
+
+    if fm_record.specific_carrier_type == "DCP":
+        return {
+            "file_name": "",  # always empty for DCP
+            "folder_name": file_path.parent.parent,
+            "sub_folder_name": file_path.parent,
+            "file_type": "DCP",
+        }
+    elif fm_record.specific_carrier_type == "DPX":
+        return {
+            "file_name": "",  # always empty for DPX
+            "folder_name": file_path.parent,
+            "file_type": "DPX",
+        }
+    else:
+        return {
+            "file_name": file_path.name,
+        }

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -2,7 +2,7 @@ import logging
 
 from fmrest.record import Record
 from pathlib import PureWindowsPath, PurePosixPath
-from .utils import cleanup_production_type, parse_date
+from .utils import cleanup_production_type, parse_date, format_date
 
 
 # Code which extracts data from a Filemaker record.
@@ -184,10 +184,24 @@ def get_uuid(fm_record: Record) -> str:
 def get_creation_date(fm_record: Record) -> str:
     """Get the creation date from a Filemaker record.
 
+    NOTE: this field is derived from FM item records, not inventory records,
+    hence why it's handled separately from the other date fields.
+
     :param fm_record: A Filemaker record.
     :return: The creation date as a string.
     """
-    return fm_record["Creation_date"]  # note capitalization in field name
+    # Specs require `creation_date` to be in "%Y-%m-%d" format,
+    # raising an error if parsing fails.
+    creation_date = format_date(fm_record["Creation_date"], "%Y-%m-%d")
+    if not creation_date:
+        message = (
+            f"Failed to parse creation date '{fm_record["Creation_date"]}' "
+            f"for record {fm_record.recordId}"
+        )
+        logger.error(message)
+        # Specs say to fail batch if any `creation_date` is invalid
+        raise ValueError(message)
+    return creation_date
 
 
 def get_asset_type(fm_record: Record) -> str:

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -3,6 +3,7 @@ import logging
 from fmrest.record import Record
 from pathlib import PureWindowsPath, PurePosixPath
 from .utils import cleanup_production_type, parse_date, format_date
+from warnings import deprecated
 
 
 # Code which extracts data from a Filemaker record.
@@ -11,6 +12,9 @@ from .utils import cleanup_production_type, parse_date, format_date
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    "Use `get_inventory_ids()` instead, as MAMS expects `inventory_ids: list[str]`"
+)
 def get_inventory_id(fm_record: Record) -> str:
     """Get the inventory id from a Filemaker record.
 
@@ -20,18 +24,22 @@ def get_inventory_id(fm_record: Record) -> str:
     return str(fm_record.inventory_id)
 
 
-def get_inventory_ids(fm_record: Record) -> list[str]:
-    """Get the inventory ids from a Filemaker record,
+def get_inventory_ids(fm_inventory_record: Record) -> list[str]:
+    """Get the inventory ids from a Filemaker inventory record,
     parsing comma-separated values into a list of strings.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: A list of inventory ids.
     """
     return [
-        inventory_id.strip() for inventory_id in str(fm_record.inventory_id).split(",")
+        inventory_id.strip()
+        for inventory_id in str(fm_inventory_record.inventory_id).split(",")
     ]
 
 
+@deprecated(
+    "Use `get_inventory_numbers()` instead, as MAMS expects `inventory_numbers: list[str]`"
+)
 def get_inventory_number(fm_record: Record) -> str:
     """Get the inventory number from a Filemaker record.
 
@@ -41,59 +49,59 @@ def get_inventory_number(fm_record: Record) -> str:
     return fm_record.inventory_no
 
 
-def get_inventory_numbers(fm_record: Record) -> list[str]:
-    """Get the inventory numbers from a Filemaker record,
+def get_inventory_numbers(fm_inventory_record: Record) -> list[str]:
+    """Get the inventory numbers from a Filemaker inventory record,
     parsing comma-separated values into a list of strings.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: A list of inventory numbers.
     """
     return [
         inventory_number.strip()
-        for inventory_number in fm_record.inventory_no.split(",")
+        for inventory_number in fm_inventory_record.inventory_no.split(",")
     ]
 
 
-def is_series_production_type(fm_record: Record) -> bool:
+def is_series_production_type(fm_inventory_record: Record) -> bool:
     """Determine if the `production_type` field represents a series,
     based on certain keywords defined in FTVA specs.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: True if the production type is a series, False otherwise.
     """
 
-    production_type = cleanup_production_type(fm_record.production_type)
+    production_type = cleanup_production_type(fm_inventory_record.production_type)
     series_keywords = ["television series", "mini-series", "serials", "news"]
     # Look for any of the keywords in the production type list
     return any(keyword in production_type for keyword in series_keywords)
 
 
-def get_creators(fm_record: Record) -> list:
-    """Get the creators from a Filemaker record.
+def get_creators(fm_inventory_record: Record) -> list:
+    """Get the creators from a Filemaker inventory record.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: A list of creators.
     """
     # Currently splitting on commas,
     # as that appears to be how the data is formatted in Filemaker.
     # If other delimiters are used, they should probably be made consistent on the FM side.
-    return [creator.strip() for creator in fm_record.director.split(",")]
+    return [creator.strip() for creator in fm_inventory_record.director.split(",")]
 
 
-def get_language_name(fm_record: Record) -> str:
-    """Get the language name from a Filemaker record.
+def get_language_name(fm_inventory_record: Record) -> str:
+    """Get the language name from a Filemaker inventory record.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: The language name as a string.
     """
     # NOTE: field name is capitalized in FM
-    return fm_record.Language
+    return fm_inventory_record.Language
 
 
-def get_date_info(fm_record: Record) -> dict:
-    """Get the date info from a Filemaker record.
+def get_date_info(fm_inventory_record: Record) -> dict:
+    """Get the date info from a Filemaker inventory record.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: A dict containing the date info.
     """
     # If FM data has `release_broadcast_year`, map it to `release_broadcast_date`.
@@ -101,61 +109,86 @@ def get_date_info(fm_record: Record) -> dict:
     # Else, return an empty dict.
     date_info = {}
 
-    if fm_record.release_broadcast_year.strip() != "":
+    if fm_inventory_record.release_broadcast_year.strip() != "":
         date_info["release_broadcast_date"] = parse_date(
-            fm_record.release_broadcast_year
+            fm_inventory_record.release_broadcast_year
         )
-    elif fm_record.record_date.strip() != "":
-        date_info["production_date"] = parse_date(fm_record.record_date)
+    elif fm_inventory_record.record_date.strip() != "":
+        date_info["production_date"] = parse_date(fm_inventory_record.record_date)
 
     return date_info
 
 
-def is_compilation(fm_record: Record) -> bool:
+def get_creation_date(fm_item_record: Record) -> str:
+    """Get the creation date from a Filemaker item record.
+
+    NOTE: this field is derived from FM item records, not inventory records,
+    hence why it's handled separately from the other date fields.
+
+    :param fm_item_record: A Filemaker item record.
+    :return: The creation date as a string.
+    :raises ValueError: If the creation date cannot be parsed.
+    """
+    # Specs require `creation_date` to be in "%Y-%m-%d" format,
+    # raising an error if parsing fails.
+    try:
+        creation_date = format_date(fm_item_record["Creation_date"], "%Y-%m-%d")
+    except ValueError as e:
+        message = (
+            f"Failed to parse creation date for record {fm_item_record.recordId}: {e}"
+        )
+        logger.error(message)
+        raise ValueError(message) from e
+    return creation_date
+
+
+def is_compilation(fm_inventory_record: Record) -> bool:
     """Determine if the `production_type` field represents a compilation,
     based on certain keywords defined in FTVA specs.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: True if the production type is a compilation, False otherwise.
     """
 
-    production_type = cleanup_production_type(fm_record.production_type)
-    title = fm_record.title.lower()
+    production_type = cleanup_production_type(fm_inventory_record.production_type)
+    title = fm_inventory_record.title.lower()
     if "compilation" in production_type or "compilation" in title:
         return True
     return False
 
 
-def get_title_info(fm_record: Record, is_series: bool) -> dict:
-    """Get the title info from a Filemaker record.
+def get_title_info(fm_inventory_record: Record, is_series: bool) -> dict:
+    """Get the title info from a Filemaker inventory record.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :param is_series: Whether the record is a series.
     :return: A dict containing the title info.
     """
-    if is_compilation(fm_record):
+    if is_compilation(fm_inventory_record):
         logger.info(
-            f"Record with inventory id {fm_record.inventory_id} is identified as a compilation. "
-            f"Production type: {fm_record.production_type}, title: {fm_record.title}"
+            f"Record with inventory id {fm_inventory_record.inventory_id} "
+            "is identified as a compilation. "
+            f"Production type: {fm_inventory_record.production_type}, "
+            f"title: {fm_inventory_record.title}"
         )
         return {}
 
-    fm_title = fm_record.title.strip()
+    fm_title = fm_inventory_record.title.strip()
     # If no title found, log a warning and return an empty dict.
     if not fm_title:
         logger.warning(
-            f"Record with inventory id {fm_record.inventory_id} has no title. "
+            f"Record with inventory id {fm_inventory_record.inventory_id} has no title. "
         )
         return {}
     # If not a series, just return the title as-is.
     if not is_series:
-        return {"title": fm_record.title}
+        return {"title": fm_inventory_record.title}
 
     # For series, we want the series title, episode title, and episode number (if available).
 
-    fm_ep_title = fm_record.episode_title.strip()
+    fm_ep_title = fm_inventory_record.episode_title.strip()
     # Space in field name means we have to use dict-style access to get the episode number field.
-    fm_ep_no = fm_record["episode no."].strip()
+    fm_ep_no = fm_inventory_record["episode no."].strip()
 
     if fm_title and fm_ep_title and fm_ep_no:
         series_title = fm_title
@@ -188,18 +221,24 @@ def get_title_info(fm_record: Record, is_series: bool) -> dict:
         return {"title": fm_title}
 
 
-def get_source_ids(fm_record: Record) -> list[str]:
-    """Get the source identifiers from a Filemaker record.
+def get_source_ids(fm_inventory_record: Record) -> list[str]:
+    """Get the source identifiers from a Filemaker inventory record.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: A list of source identifiers.
     """
     # `source_identifier` field in FM should have comma-separated values
-    return [source_id.strip() for source_id in fm_record.source_identifier.split(",")]
+    return [
+        source_id.strip()
+        for source_id in fm_inventory_record.source_identifier.split(",")
+    ]
 
 
 def get_uuid(fm_record: Record) -> str:
     """Get the UUID from a Filemaker record.
+
+    NOTE: this field is present on both inventory and item records,
+    hence the generic `fm_record` parameter.
 
     :param fm_record: A Filemaker record.
     :return: The UUID as a string.
@@ -207,91 +246,77 @@ def get_uuid(fm_record: Record) -> str:
     return fm_record["UUID"]  # field name is capitalized in FM
 
 
-def get_creation_date(fm_record: Record) -> str:
-    """Get the creation date from a Filemaker record.
+def get_asset_type(fm_inventory_record: Record) -> str:
+    """Get the asset type from a Filemaker inventory record.
 
-    NOTE: this field is derived from FM item records, not inventory records,
-    hence why it's handled separately from the other date fields.
-
-    :param fm_record: A Filemaker record.
-    :return: The creation date as a string.
-    """
-    # Specs require `creation_date` to be in "%Y-%m-%d" format,
-    # raising an error if parsing fails.
-    creation_date = format_date(fm_record["Creation_date"], "%Y-%m-%d")
-    if not creation_date:
-        message = (
-            f"Failed to parse creation date '{fm_record["Creation_date"]}' "
-            f"for record {fm_record.recordId}"
-        )
-        logger.error(message)
-        # Specs say to fail batch if any `creation_date` is invalid
-        raise ValueError(message)
-    return creation_date
-
-
-def get_asset_type(fm_record: Record) -> str:
-    """Get the asset type from a Filemaker record.
-
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: The asset type as a string.
     """
-    return fm_record.asset_type
+    return fm_inventory_record.asset_type
 
 
-def get_media_type(fm_record: Record) -> str:
-    """Get the media type from a Filemaker record.
+def get_media_type(fm_inventory_record: Record) -> str:
+    """Get the media type from a Filemaker inventory record.
 
-    :param fm_record: A Filemaker record.
+    :param fm_inventory_record: A Filemaker inventory record.
     :return: The media type as a string.
     """
     # Specs require media type to be one of "Audio", "Image", or "Video",
     # raising an error if it's not
-    media_type = fm_record.media_type
+    media_type = fm_inventory_record.media_type
     if media_type not in ["Audio", "Image", "Video"]:
-        message = f"Invalid media type '{media_type}' for record {fm_record.recordId}"
+        message = f"Invalid media type '{media_type}' for record {fm_inventory_record.recordId}"
         logger.error(message)
         raise ValueError(message)
     return media_type
 
 
-def get_audio_class(fm_record: Record) -> str:
-    """Get the audio class from a Filemaker record.
+def get_audio_class(fm_item_record: Record) -> str:
+    """Get the audio class from a Filemaker item record.
 
-    :param fm_record: A Filemaker record.
+    :param fm_item_record: A Filemaker item record.
     :return: The audio class as a string.
     """
     # Specs say to return "Unknown" if this field is an empty string
-    return fm_record.audio_class if fm_record.audio_class.strip() != "" else "Unknown"
+    return (
+        fm_item_record.audio_class
+        if fm_item_record.audio_class.strip() != ""
+        else "Unknown"
+    )
 
 
-def get_file_path_info(fm_record: Record) -> dict:
-    """Get the file path info from a Filemaker record.
+def get_file_path_info(fm_item_record: Record) -> dict:
+    """Get the file path info from a Filemaker item record.
 
-    :param fm_record: A Filemaker record.
+    :param fm_item_record: A Filemaker item record.
     :return: A dict containing the file path info.
+    :raises TypeError: If the file path field is not a string.
     """
-    raw_value = fm_record.file_path
+    raw_value = fm_item_record.file_path
     try:
-        # If raw value contains "\\", treat it as a Windows path,
+        # If raw value contains backslashes,
+        # treat it as a Windows path,
         # otherwise treat it as a POSIX path
         file_path = (
             PureWindowsPath(raw_value)
-            if "\\" in raw_value
+            if "\\" in raw_value  # this is an escaped single backslash
             else PurePosixPath(raw_value)
         )
     # Raise an error if the value cannot be converted to a path
-    except ValueError:
-        message = f"Invalid file path '{raw_value}' for record {fm_record.recordId}"
+    except TypeError:
+        message = (
+            f"File path field must be a string, "
+            f"not {type(raw_value)} for record {fm_item_record.recordId}"
+        )
         logger.error(message)
-        raise ValueError(message)
+        raise TypeError(message)
     # Same logic for DCP and DPX: `file_name` is always empty,
     # and `folder_name` is immediate parent of file path
-    if fm_record.specific_carrier_type.lower() in ["dcp", "dpx"]:
+    if fm_item_record.specific_carrier_type.lower() in ["dcp", "dpx"]:
         return {
             "file_name": "",
             "folder_name": file_path.parent.name,
-            "file_type": fm_record.specific_carrier_type.upper(),
+            "file_type": fm_item_record.specific_carrier_type.upper(),
         }
     # If not a DCP or DPX, return just file name
     return {"file_name": file_path.name}

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -255,26 +255,18 @@ def get_file_path_info(fm_record: Record) -> dict:
             if "\\" in raw_value
             else PurePosixPath(raw_value)
         )
-
+    # Raise an error if the value cannot be converted to a path
     except ValueError:
-        logger.warning(
-            f"Filemaker record with record ID {fm_record.recordId} "
-            f"has an invalid `file_path` value: {raw_value}"
-        )
-        return {}
-
-    if fm_record.specific_carrier_type.lower() == "dcp":
+        message = f"Invalid file path '{raw_value}' for record {fm_record.recordId}"
+        logger.error(message)
+        raise ValueError(message)
+    # Same logic for DCP and DPX: `file_name` is always empty,
+    # and `folder_name` is immediate parent of file path
+    if fm_record.specific_carrier_type.lower() in ["dcp", "dpx"]:
         return {
-            "file_name": "",  # always empty for DCP
-            "folder_name": file_path.parents[1].name,  # two levels up
-            "sub_folder_name": file_path.parents[0].name,  # one level up
-            "file_type": "DCP",
-        }
-    elif fm_record.specific_carrier_type.lower() == "dpx":
-        return {
-            "file_name": "",  # always empty for DPX
-            "folder_name": file_path.parents[0].name,  # one level up
-            "file_type": "DPX",
+            "file_name": "",
+            "folder_name": file_path.parent.name,
+            "file_type": fm_record.specific_carrier_type.upper(),
         }
     # If not a DCP or DPX, return just file name
     return {"file_name": file_path.name}

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -1,7 +1,7 @@
 import logging
 
 from fmrest.record import Record
-from pathlib import PurePath
+from pathlib import PureWindowsPath, PurePosixPath
 from .utils import cleanup_production_type
 
 
@@ -226,7 +226,14 @@ def get_file_path_info(fm_record: Record) -> dict:
     """
     raw_value = fm_record.file_path
     try:
-        file_path = PurePath(raw_value)
+        # If raw value contains "\\", treat it as a Windows path,
+        # otherwise treat it as a POSIX path
+        file_path = (
+            PureWindowsPath(raw_value)
+            if "\\" in raw_value
+            else PurePosixPath(raw_value)
+        )
+
     except ValueError:
         logger.warning(
             f"Filemaker record with record ID {fm_record.recordId} "
@@ -234,20 +241,18 @@ def get_file_path_info(fm_record: Record) -> dict:
         )
         return {}
 
-    if fm_record.specific_carrier_type == "DCP":
+    if fm_record.specific_carrier_type.lower() == "dcp":
         return {
             "file_name": "",  # always empty for DCP
-            "folder_name": file_path.parent.parent,
-            "sub_folder_name": file_path.parent,
+            "folder_name": file_path.parents[1].name,  # two levels up
+            "sub_folder_name": file_path.parents[0].name,  # one level up
             "file_type": "DCP",
         }
-    elif fm_record.specific_carrier_type == "DPX":
+    elif fm_record.specific_carrier_type.lower() == "dpx":
         return {
             "file_name": "",  # always empty for DPX
-            "folder_name": file_path.parent,
+            "folder_name": file_path.parents[0].name,  # one level up
             "file_type": "DPX",
         }
-    else:
-        return {
-            "file_name": file_path.name,
-        }
+    # If not a DCP or DPX, return just file name
+    return {"file_name": file_path.name}

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -220,7 +220,14 @@ def get_media_type(fm_record: Record) -> str:
     :param fm_record: A Filemaker record.
     :return: The media type as a string.
     """
-    return fm_record.media_type
+    # Specs require media type to be one of "Audio", "Image", or "Video",
+    # raising an error if it's not
+    media_type = fm_record.media_type
+    if media_type not in ["Audio", "Image", "Video"]:
+        message = f"Invalid media type '{media_type}' for record {fm_record.recordId}"
+        logger.error(message)
+        raise ValueError(message)
+    return media_type
 
 
 def get_audio_class(fm_record: Record) -> str:

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -163,13 +163,14 @@ def get_title_info(fm_record: Record, is_series: bool) -> dict:
         return {"title": fm_title}
 
 
-def get_source_id(fm_record: Record) -> str:
-    """Get the source identifier from a Filemaker record.
+def get_source_ids(fm_record: Record) -> list[str]:
+    """Get the source identifiers from a Filemaker record.
 
     :param fm_record: A Filemaker record.
-    :return: The source identifier as a string.
+    :return: A list of source identifiers.
     """
-    return fm_record.source_identifier
+    # `source_identifier` field in FM should have comma-separated values
+    return [source_id.strip() for source_id in fm_record.source_identifier.split(",")]
 
 
 def get_uuid(fm_record: Record) -> str:

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -2,7 +2,7 @@ import logging
 
 from fmrest.record import Record
 from pathlib import PureWindowsPath, PurePosixPath
-from .utils import cleanup_production_type
+from .utils import cleanup_production_type, parse_date
 
 
 # Code which extracts data from a Filemaker record.
@@ -74,14 +74,14 @@ def get_date_info(fm_record: Record) -> dict:
     # If FM data has `release_broadcast_year`, map it to `release_broadcast_date`.
     # Else, if FM data has `record_date`, map it to `production_date`.
     # Else, return an empty dict.
-    # NOTE: we're taking values as-is from FM here,
-    # mapping them to the date-like keys in the MAMS metadata.
     date_info = {}
 
     if fm_record.release_broadcast_year.strip() != "":
-        date_info["release_broadcast_date"] = fm_record.release_broadcast_year
+        date_info["release_broadcast_date"] = parse_date(
+            fm_record.release_broadcast_year
+        )
     elif fm_record.record_date.strip() != "":
-        date_info["production_date"] = fm_record.record_date
+        date_info["production_date"] = parse_date(fm_record.record_date)
 
     return date_info
 

--- a/src/ftva_etl/metadata/mams_metadata_ndm.py
+++ b/src/ftva_etl/metadata/mams_metadata_ndm.py
@@ -7,7 +7,7 @@ from spacy.language import Language
 from .filemaker import (
     get_inventory_id,
     get_inventory_number,
-    get_source_id,
+    get_source_ids,
     is_series_production_type,
     get_creators as get_fm_creators,
     get_date_info as get_fm_date_info,
@@ -60,7 +60,7 @@ def get_mams_metadata_ndm(
         "inventory_id": get_inventory_id(fm_inventory_record),
         # MAMS expects list for `inventory_numbers` field
         "inventory_numbers": [get_inventory_number(fm_inventory_record)],
-        "source_id": get_source_id(fm_inventory_record),
+        "source_ids": get_source_ids(fm_inventory_record),
         "creators": get_fm_creators(fm_inventory_record),
         "language": get_fm_language_name(fm_inventory_record),
         "asset_type": get_asset_type(fm_inventory_record),

--- a/src/ftva_etl/metadata/mams_metadata_ndm.py
+++ b/src/ftva_etl/metadata/mams_metadata_ndm.py
@@ -1,5 +1,4 @@
 import spacy
-import logging
 
 from fmrest.record import Record as FM_Record
 from pymarc import Record as Pymarc_Record
@@ -30,72 +29,6 @@ from .marc import (
 )
 
 
-# Create a module logger, which will be a child of the package logger
-logger = logging.getLogger(__name__)
-
-
-def get_alma_metadata(
-    bib_record: Pymarc_Record, nlp_model: Language, is_series: bool = False
-) -> dict:
-    """Get the Alma metadata from a pymarc record.
-
-    :param bib_record: A pymarc record.
-    :param nlp_model: A spacy language model to use for NER.
-    :param is_series: Whether the record is a series, derived from Filemaker record.
-        Defaults to False.
-    :return: A dict containing the Alma metadata needed for the MAMS.
-    """
-    return {
-        "alma_bib_id": get_bib_id(bib_record),
-        "language": get_alma_language_name(bib_record),
-        "creators": get_alma_creators(bib_record, nlp_model),
-        **get_alma_title_info(bib_record, is_series),
-        **get_alma_date_info(bib_record),
-    }
-
-
-def get_filemaker_metadata_from_inventory_record(
-    fm_inventory_record: FM_Record, is_series: bool
-) -> dict:
-    """Get Filemaker metadata from the provided inventory record.
-
-    :param fm_inventory_record: A Filemaker record containing inventory data.
-    :param is_series: Whether the record is a series.
-    :return: A dict containing the Filemaker metadata needed for the MAMS.
-    """
-    return {
-        "inventory_id": get_inventory_id(fm_inventory_record),
-        # All records returned from FM
-        # should have only one inventory number for now,
-        # but MAMS expects an array in JSON, so wrap in a list.
-        # TODO: Parse comma-separated or otherwise delimited inventory numbers
-        # from FM or other sources, if needed.
-        "inventory_numbers": [get_inventory_number(fm_inventory_record)],
-        "source_id": get_source_id(fm_inventory_record),
-        "creators": get_fm_creators(fm_inventory_record),
-        "language": get_fm_language_name(fm_inventory_record),
-        "asset_type": get_asset_type(fm_inventory_record),
-        "media_type": get_media_type(fm_inventory_record),
-        **get_fm_title_info(fm_inventory_record, is_series),
-        **get_fm_date_info(fm_inventory_record),
-    }
-
-
-def get_filemaker_metadata_from_item_record(fm_item_record: FM_Record) -> dict:
-    """Get Filemaker metadata from the provided item record.
-
-    :param fm_item_record: A Filemaker record containing item data.
-    :param is_series: Whether the record is a series.
-    :return: A dict containing the Filemaker metadata needed for the MAMS.
-    """
-    return {
-        "uuid": get_uuid(fm_item_record),
-        "creation_date": get_creation_date(fm_item_record),
-        "audio_class": get_audio_class(fm_item_record),
-        **get_file_path_info(fm_item_record),
-    }
-
-
 def get_mams_metadata_ndm(
     fm_item_record: FM_Record,
     fm_inventory_record: FM_Record,
@@ -122,15 +55,36 @@ def get_mams_metadata_ndm(
     # Filemaker is the source-of-truth for whether something is a series.
     is_series = is_series_production_type(fm_inventory_record)
 
-    fm_metadata_from_item_record = get_filemaker_metadata_from_item_record(
-        fm_item_record
-    )
-    fm_metadata_from_inventory_record = get_filemaker_metadata_from_inventory_record(
-        fm_inventory_record, is_series
-    )
+    # These fields are derived from `fm_inventory_record`...
+    fm_inventory_record_metadata = {
+        "inventory_id": get_inventory_id(fm_inventory_record),
+        # MAMS expects list for `inventory_numbers` field
+        "inventory_numbers": [get_inventory_number(fm_inventory_record)],
+        "source_id": get_source_id(fm_inventory_record),
+        "creators": get_fm_creators(fm_inventory_record),
+        "language": get_fm_language_name(fm_inventory_record),
+        "asset_type": get_asset_type(fm_inventory_record),
+        "media_type": get_media_type(fm_inventory_record),
+        **get_fm_title_info(fm_inventory_record, is_series),
+        **get_fm_date_info(fm_inventory_record),
+    }
+
+    # ...and these fields are derived from `fm_item_record`
+    fm_item_record_metadata = {
+        "uuid": get_uuid(fm_item_record),
+        "creation_date": get_creation_date(fm_item_record),
+        "audio_class": get_audio_class(fm_item_record),
+        **get_file_path_info(fm_item_record),
+    }
 
     alma_metadata = (
-        get_alma_metadata(alma_bib_record, nlp_model, is_series)
+        {
+            "alma_bib_id": get_bib_id(alma_bib_record),
+            "language": get_alma_language_name(alma_bib_record),
+            "creators": get_alma_creators(alma_bib_record, nlp_model),
+            **get_alma_title_info(alma_bib_record, is_series),
+            **get_alma_date_info(alma_bib_record),
+        }
         if alma_bib_record
         else {}
     )
@@ -138,8 +92,8 @@ def get_mams_metadata_ndm(
     # Unpack fields from Filemaker into a single metadata object...
     metadata = {
         "record_type": "asset",  # default to asset record type
-        **fm_metadata_from_item_record,
-        **fm_metadata_from_inventory_record,
+        **fm_item_record_metadata,
+        **fm_inventory_record_metadata,
     }
 
     # ...and if Alma metadata is available, update the metadata dict with Alma fields

--- a/src/ftva_etl/metadata/mams_metadata_ndm.py
+++ b/src/ftva_etl/metadata/mams_metadata_ndm.py
@@ -106,4 +106,5 @@ def get_mams_metadata_ndm(
         metadata["record_type"] = "track"
         metadata["match_asset"] = match_asset
 
-    return metadata
+    # Sort the output dict by its keys, just to make review easier
+    return dict(sorted(metadata.items()))

--- a/src/ftva_etl/metadata/mams_metadata_ndm.py
+++ b/src/ftva_etl/metadata/mams_metadata_ndm.py
@@ -8,11 +8,18 @@ from spacy.language import Language
 from .filemaker import (
     get_inventory_id,
     get_inventory_number,
+    get_source_id,
     is_series_production_type,
     get_creators as get_fm_creators,
     get_date_info as get_fm_date_info,
     get_language_name as get_fm_language_name,
     get_title_info as get_fm_title_info,
+    get_uuid,
+    get_creation_date,
+    get_asset_type,
+    get_media_type,
+    get_audio_class,
+    get_file_path_info,
 )
 from .marc import (
     get_bib_id,
@@ -38,57 +45,55 @@ def get_alma_metadata(
         Defaults to False.
     :return: A dict containing the Alma metadata needed for the MAMS.
     """
-    # This gets a collection of titles which will be unpacked later.
-    titles = get_alma_title_info(bib_record, is_series)
     return {
         "alma_bib_id": get_bib_id(bib_record),
         "language": get_alma_language_name(bib_record),
         "creators": get_alma_creators(bib_record, nlp_model),
-        **titles,
+        **get_alma_title_info(bib_record, is_series),
         **get_alma_date_info(bib_record),
     }
 
 
-def get_filemaker_metadata(filemaker_record: FM_Record, is_series: bool) -> dict:
-    """Get the Filemaker metadata from a Filemaker record.
+def get_filemaker_metadata_from_inventory_record(
+    fm_inventory_record: FM_Record, is_series: bool
+) -> dict:
+    """Get Filemaker metadata from the provided inventory record.
 
-    :param filemaker_record: A Filemaker record.
-    :param is_series: Whether the record is a series, derived from Filemaker record.
+    :param fm_inventory_record: A Filemaker record containing inventory data.
+    :param is_series: Whether the record is a series.
     :return: A dict containing the Filemaker metadata needed for the MAMS.
     """
-    titles = get_fm_title_info(filemaker_record, is_series)
     return {
-        "inventory_id": get_inventory_id(filemaker_record),
+        "inventory_id": get_inventory_id(fm_inventory_record),
         # All records returned from FM
         # should have only one inventory number for now,
         # but MAMS expects an array in JSON, so wrap in a list.
         # TODO: Parse comma-separated or otherwise delimited inventory numbers
         # from FM or other sources, if needed.
-        "inventory_numbers": [get_inventory_number(filemaker_record)],
-        "creators": get_fm_creators(filemaker_record),
-        "language": get_fm_language_name(filemaker_record),
-        **titles,
-        **get_fm_date_info(filemaker_record),
+        "inventory_numbers": [get_inventory_number(fm_inventory_record)],
+        "source_id": get_source_id(fm_inventory_record),
+        "creators": get_fm_creators(fm_inventory_record),
+        "language": get_fm_language_name(fm_inventory_record),
+        "asset_type": get_asset_type(fm_inventory_record),
+        "media_type": get_media_type(fm_inventory_record),
+        **get_fm_title_info(fm_inventory_record, is_series),
+        **get_fm_date_info(fm_inventory_record),
     }
 
 
-def _get_descriptive_metadata(source_metadata: dict) -> dict:
-    """Utility for extracting descriptive metadata fields from the provided source,
-    i.e. `creators`, `language`, and all title and date fields.
-    Since these fields are common to both Alma and Filemaker sources,
-    and Alma is preferred as a source when present, but is not required,
-    this function is a reusable utility for extracting these fields from either source.
+def get_filemaker_metadata_from_item_record(fm_item_record: FM_Record) -> dict:
+    """Get Filemaker metadata from the provided item record.
 
-    :param source_metadata: A dict containing source metadata (i.e. either from Filemaker or Alma).
-    :return: A dict containing descriptive metadata fields from the source metadata.
+    :param fm_item_record: A Filemaker record containing item data.
+    :param is_series: Whether the record is a series.
+    :return: A dict containing the Filemaker metadata needed for the MAMS.
     """
-    output = {
-        "creators": source_metadata.get("creators", []),
-        "language": source_metadata.get("language", ""),
-        **{k: v for k, v in source_metadata.items() if "title" in k},
-        **{k: v for k, v in source_metadata.items() if "date" in k},
+    return {
+        "uuid": get_uuid(fm_item_record),
+        "creation_date": get_creation_date(fm_item_record),
+        "audio_class": get_audio_class(fm_item_record),
+        **get_file_path_info(fm_item_record),
     }
-    return output
 
 
 def get_mams_metadata_ndm(
@@ -117,7 +122,12 @@ def get_mams_metadata_ndm(
     # Filemaker is the source-of-truth for whether something is a series.
     is_series = is_series_production_type(fm_inventory_record)
 
-    filemaker_metadata = get_filemaker_metadata(fm_inventory_record, is_series)
+    fm_metadata_from_item_record = get_filemaker_metadata_from_item_record(
+        fm_item_record
+    )
+    fm_metadata_from_inventory_record = get_filemaker_metadata_from_inventory_record(
+        fm_inventory_record, is_series
+    )
 
     alma_metadata = (
         get_alma_metadata(alma_bib_record, nlp_model, is_series)
@@ -125,24 +135,21 @@ def get_mams_metadata_ndm(
         else {}
     )
 
-    # These are the fields from Filemaker
-    filemaker_fields = {
-        "inventory_id": filemaker_metadata.get("inventory_id", ""),
-        "inventory_numbers": filemaker_metadata.get("inventory_numbers", []),
-        **_get_descriptive_metadata(filemaker_metadata),
-    }
-
     # Unpack fields from Filemaker into a single metadata object...
     metadata = {
-        **filemaker_fields,
+        "record_type": "asset",  # default to asset record type
+        **fm_metadata_from_item_record,
+        **fm_metadata_from_inventory_record,
     }
 
     # ...and if Alma metadata is available, update the metadata dict with Alma fields
     if alma_metadata:
-        alma_fields = {
-            "alma_bib_id": alma_metadata.get("alma_bib_id", ""),
-            **_get_descriptive_metadata(alma_metadata),
-        }
-        metadata.update(alma_fields)
+        metadata.update(alma_metadata)
+
+    # ...finally add match asset information, if provided
+    if match_asset:
+        # Update record type to track if match asset is provided
+        metadata["record_type"] = "track"
+        metadata["match_asset"] = match_asset
 
     return metadata

--- a/src/ftva_etl/metadata/mams_metadata_ndm.py
+++ b/src/ftva_etl/metadata/mams_metadata_ndm.py
@@ -5,8 +5,8 @@ from pymarc import Record as Pymarc_Record
 from typing import Optional
 from spacy.language import Language
 from .filemaker import (
-    get_inventory_id,
-    get_inventory_number,
+    get_inventory_ids,
+    get_inventory_numbers,
     get_source_ids,
     is_series_production_type,
     get_creators as get_fm_creators,
@@ -57,9 +57,8 @@ def get_mams_metadata_ndm(
 
     # These fields are derived from `fm_inventory_record`...
     fm_inventory_record_metadata = {
-        "inventory_id": get_inventory_id(fm_inventory_record),
-        # MAMS expects list for `inventory_numbers` field
-        "inventory_numbers": [get_inventory_number(fm_inventory_record)],
+        "inventory_ids": get_inventory_ids(fm_inventory_record),
+        "inventory_numbers": get_inventory_numbers(fm_inventory_record),
         "source_ids": get_source_ids(fm_inventory_record),
         "creators": get_fm_creators(fm_inventory_record),
         "language": get_fm_language_name(fm_inventory_record),

--- a/src/ftva_etl/metadata/utils.py
+++ b/src/ftva_etl/metadata/utils.py
@@ -9,6 +9,21 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
+def format_date(date_string: str, format: str = "%Y-%m-%d") -> str | bool:
+    """Format a date string to a given format.
+
+    :param date_string: The date string to format.
+    :param format: The format to use. Defaults to "%Y-%m-%d".
+    :return: The formatted date string, or False if parsing fails.
+    """
+    try:
+        parsed_date = dateutil.parser.parse(date_string)
+        return parsed_date.strftime(format)
+    except dateutil.parser.ParserError:
+        # Return False if parsing fails
+        return False
+
+
 def _is_imprecise_date(date_string: str) -> bool:
     """Return True if date_string lacks full year-month-day precision.
 
@@ -50,7 +65,8 @@ def parse_date(date_string: str) -> str:
     """Parse a date string into a standardized format.
 
     :param date_string: Date string to parse.
-    :return: Formatted date string or an empty string if parsing fails."""
+    :return: Formatted date string or date string as-is if parsing fails.
+    """
 
     # If the date string is in brackets, remove them temporarily
     # Remember this so we can add them back later

--- a/src/ftva_etl/metadata/utils.py
+++ b/src/ftva_etl/metadata/utils.py
@@ -9,19 +9,19 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
-def format_date(date_string: str, format: str = "%Y-%m-%d") -> str | bool:
+def format_date(date_string: str, format: str = "%Y-%m-%d") -> str:
     """Format a date string to a given format.
 
     :param date_string: The date string to format.
     :param format: The format to use. Defaults to "%Y-%m-%d".
-    :return: The formatted date string, or False if parsing fails.
+    :return: The formatted date string.
+    :raises ValueError: If the date string cannot be parsed.
     """
     try:
         parsed_date = dateutil.parser.parse(date_string)
         return parsed_date.strftime(format)
     except dateutil.parser.ParserError:
-        # Return False if parsing fails
-        return False
+        raise ValueError(f"'{date_string}' cannot be parsed to a date")
 
 
 def _is_imprecise_date(date_string: str) -> bool:
@@ -65,7 +65,10 @@ def parse_date(date_string: str) -> str:
     """Parse a date string into a standardized format.
 
     :param date_string: Date string to parse.
-    :return: Formatted date string or date string as-is if parsing fails.
+    :return: Formatted date string, meaning:
+    - a date formatted as YYYY-MM-DD if it can be parsed to a date;
+    - the input string with trailing punctuation and whitespace removed
+      if it cannot be parsed to a date, or if it is imprecise (i.e. not year-month-day precision).
     """
 
     # If the date string is in brackets, remove them temporarily

--- a/tests/test_metadata/test_filemaker.py
+++ b/tests/test_metadata/test_filemaker.py
@@ -251,8 +251,7 @@ class TestFilemakerFilePathInfo(TestCase):
                 },
                 {
                     "file_name": "",
-                    "folder_name": "path",
-                    "sub_folder_name": "to",
+                    "folder_name": "to",
                     "file_type": "DCP",
                 },
             ),  # DCP test case

--- a/tests/test_metadata/test_filemaker.py
+++ b/tests/test_metadata/test_filemaker.py
@@ -1,9 +1,14 @@
 from unittest import TestCase
 from src.ftva_etl.metadata.filemaker import (
+    logger as fm_module_logger,
     is_series_production_type,
     get_date_info,
     get_title_info,
     get_file_path_info,
+    get_creators,
+    get_creation_date,
+    get_media_type,
+    get_audio_class,
 )
 from fmrest.record import Record
 
@@ -275,6 +280,26 @@ class TestFilemakerFilePathInfo(TestCase):
                     "file_name": "file.mp4",
                 },
             ),  # Non-DCP/DPX test case
+            (
+                {
+                    "file_path": "/path/to/file.mov",
+                    "specific_carrier_type": "MOV",
+                },
+                {
+                    "file_name": "file.mov",
+                },
+            ),  # POSIX path test case
+            (
+                {
+                    "file_path": "C:\\path\\to\\file.mp4",
+                    "specific_carrier_type": "dcp",
+                },
+                {
+                    "file_name": "",
+                    "folder_name": "to",
+                    "file_type": "DCP",
+                },
+            ),  # Lowercase DCP test case
         ]
         self.test_records = [
             Record(
@@ -298,3 +323,111 @@ class TestFilemakerFilePathInfo(TestCase):
                     get_file_path_info(record),
                     expected_result,
                 )
+
+
+class TestFilemakerCreators(TestCase):
+    def setUp(self):
+        test_cases = [
+            # Comma-separated values are split and stripped
+            (
+                "Spielberg, Scorsese ,Coppola",
+                ["Spielberg", "Scorsese", "Coppola"],
+            ),
+            # Non-comma value returned as a single-element list as-is
+            (
+                "Moss and Lewis ; Revue Studios ; Richard Lewis Productions.",
+                ["Moss and Lewis ; Revue Studios ; Richard Lewis Productions."],
+            ),
+            (
+                "Ford Beebe & Cliff Smith",
+                ["Ford Beebe & Cliff Smith"],
+            ),
+        ]
+        self.test_records = [
+            (
+                Record(
+                    keys=["recordId", "modId", "director"],
+                    values=[index, 0, director],
+                ),
+                expected,
+            )
+            for index, (director, expected) in enumerate(test_cases)
+        ]
+
+    def test_get_creators(self):
+        """Test that `get_creators` splits comma-separated values
+        and leaves values with other delimiters as-is.
+        """
+        for record, expected_result in self.test_records:
+            with self.subTest(record=record):
+                self.assertEqual(get_creators(record), expected_result)
+
+
+class TestFilemakerCreationDate(TestCase):
+    def test_get_creation_date_us_style(self):
+        """Test that US-style dates are formatted as YYYY-MM-DD."""
+        record = Record(
+            keys=["recordId", "modId", "Creation_date"],
+            values=[1, 0, "07/16/2026"],
+        )
+        self.assertEqual(get_creation_date(record), "2026-07-16")
+
+    def test_invalid_creation_date_logs_and_raises(self):
+        """Test that non-date values log an error then raise ValueError."""
+        record = Record(
+            keys=["recordId", "modId", "Creation_date"],
+            values=[1, 0, "not-a-date"],
+        )
+        with self.assertLogs(fm_module_logger, level="ERROR") as log_context:
+            with self.assertRaises(ValueError) as error_context:
+                get_creation_date(record)
+        expected_message = "Failed to parse creation date 'not-a-date' for record 1"
+        # Assert that the error contains the expected message
+        self.assertIn(expected_message, str(error_context.exception))
+        # Assert that the logs contain the expected message
+        self.assertIn(expected_message, log_context.output[0])
+
+
+class TestFilemakerMediaType(TestCase):
+    def test_get_media_type_allowlist(self):
+        """Test that allowlisted media types are returned unchanged."""
+        for media_type in ["Audio", "Image", "Video"]:
+            with self.subTest(media_type=media_type):
+                record = Record(
+                    keys=["recordId", "modId", "media_type"],
+                    values=[1, 0, media_type],
+                )
+                self.assertEqual(get_media_type(record), media_type)
+
+    def test_invalid_media_type_logs_and_raises(self):
+        """Test that non-allowlisted values log an error then raise ValueError."""
+        for media_type in ["Film", ""]:
+            with self.subTest(media_type=media_type):
+                record = Record(
+                    keys=["recordId", "modId", "media_type"],
+                    values=[1, 0, media_type],
+                )
+                with self.assertLogs(fm_module_logger, level="ERROR") as log_context:
+                    with self.assertRaises(ValueError) as error_context:
+                        get_media_type(record)
+                expected_message = f"Invalid media type '{media_type}' for record 1"
+                # Assert that the error contains the expected message
+                self.assertIn(expected_message, str(error_context.exception))
+                # Assert that the logs contain the expected message
+                self.assertIn(expected_message, log_context.output[0])
+
+
+class TestFilemakerAudioClass(TestCase):
+    def test_get_audio_class(self):
+        """Test that empty audio_class maps to Unknown and non-empty values pass through."""
+        test_cases = [
+            ("", "Unknown"),
+            ("Dialogue", "Dialogue"),
+        ]
+        for audio_class, expected in test_cases:
+            with self.subTest(audio_class=audio_class):
+                record = Record(
+                    keys=["recordId", "modId", "audio_class"],
+                    values=[1, 0, audio_class],
+                )
+                self.assertEqual(get_audio_class(record), expected)

--- a/tests/test_metadata/test_filemaker.py
+++ b/tests/test_metadata/test_filemaker.py
@@ -78,7 +78,7 @@ class TestFilemakerDateInfo(TestCase):
             ),
             # only record_date present
             (
-                {"release_broadcast_year": "", "record_date": "11/9/2004"},
+                {"release_broadcast_year": "", "record_date": "2004-11-09"},
                 {"production_date": "2004-11-09"},
             ),
             # neither present
@@ -90,6 +90,26 @@ class TestFilemakerDateInfo(TestCase):
             (
                 {"release_broadcast_year": "Unknown", "record_date": "Unknown"},
                 {"release_broadcast_date": "Unknown"},
+            ),
+            # Value is imprecise (i.e. not year-month-day precision)
+            (
+                {"release_broadcast_year": "", "record_date": "2026-07"},
+                {"production_date": "2026-07"},
+            ),
+            # US-style date should be formatted as YYYY-MM-DD
+            (
+                {"release_broadcast_year": "", "record_date": "11/9/2004"},
+                {"production_date": "2004-11-09"},
+            ),
+            # Brackets should be preserved
+            (
+                {"release_broadcast_year": "[1997]", "record_date": ""},
+                {"release_broadcast_date": "[1997]"},
+            ),
+            # Trailing punctuation and whitespace should be removed
+            (
+                {"release_broadcast_year": " 1994.", "record_date": ""},
+                {"release_broadcast_date": "1994"},
             ),
         ]
 
@@ -324,6 +344,23 @@ class TestFilemakerFilePathInfo(TestCase):
                     expected_result,
                 )
 
+    def test_invalid_file_path_logs_and_raises(self):
+        """Test that non-string file path values log an error then raise TypeError."""
+        record = Record(
+            keys=["recordId", "modId", "file_path"],
+            values=[1, 0, 123],  # `file_path` is an integer, which is invalid
+        )
+        with self.assertLogs(fm_module_logger, level="ERROR") as log_context:
+            with self.assertRaises(TypeError) as error_context:
+                get_file_path_info(record)
+        expected_message = (
+            "File path field must be a string, not <class 'int'> for record 1"
+        )
+        # Assert that the error contains the expected message
+        self.assertIn(expected_message, str(error_context.exception))
+        # Assert that the logs contain the expected message
+        self.assertIn(expected_message, log_context.output[0])
+
 
 class TestFilemakerCreators(TestCase):
     def setUp(self):
@@ -381,7 +418,10 @@ class TestFilemakerCreationDate(TestCase):
         with self.assertLogs(fm_module_logger, level="ERROR") as log_context:
             with self.assertRaises(ValueError) as error_context:
                 get_creation_date(record)
-        expected_message = "Failed to parse creation date 'not-a-date' for record 1"
+        expected_message = (
+            "Failed to parse creation date for record 1: "
+            "'not-a-date' cannot be parsed to a date"
+        )
         # Assert that the error contains the expected message
         self.assertIn(expected_message, str(error_context.exception))
         # Assert that the logs contain the expected message

--- a/tests/test_metadata/test_filemaker.py
+++ b/tests/test_metadata/test_filemaker.py
@@ -3,6 +3,7 @@ from src.ftva_etl.metadata.filemaker import (
     is_series_production_type,
     get_date_info,
     get_title_info,
+    get_file_path_info,
 )
 from fmrest.record import Record
 
@@ -73,12 +74,17 @@ class TestFilemakerDateInfo(TestCase):
             # only record_date present
             (
                 {"release_broadcast_year": "", "record_date": "11/9/2004"},
-                {"production_date": "11/9/2004"},
+                {"production_date": "2004-11-09"},
             ),
             # neither present
             (
                 {"release_broadcast_year": "", "record_date": ""},
                 {},
+            ),
+            # Value is `Unknown`
+            (
+                {"release_broadcast_year": "Unknown", "record_date": "Unknown"},
+                {"release_broadcast_date": "Unknown"},
             ),
         ]
 
@@ -229,5 +235,67 @@ class TestFilemakerTitleInfo(TestCase):
             with self.subTest(record=record):
                 self.assertDictEqual(
                     get_title_info(record, is_series_production_type(record)),
+                    expected_result,
+                )
+
+
+class TestFilemakerFilePathInfo(TestCase):
+    def setUp(self):
+        # Test cases are tuples, where 1st elem is input file path info,
+        # and 2nd elem is expected result from get_file_path_info().
+        test_cases = [
+            (
+                {
+                    "file_path": "C:\\path\\to\\file.mp4",
+                    "specific_carrier_type": "DCP",
+                },
+                {
+                    "file_name": "",
+                    "folder_name": "path",
+                    "sub_folder_name": "to",
+                    "file_type": "DCP",
+                },
+            ),  # DCP test case
+            (
+                {
+                    "file_path": "C:\\path\\to\\file.mp4",
+                    "specific_carrier_type": "DPX",
+                },
+                {
+                    "file_name": "",
+                    "folder_name": "to",
+                    "file_type": "DPX",
+                },
+            ),  # DPX test case
+            (
+                {
+                    "file_path": "C:\\path\\to\\file.mp4",
+                    "specific_carrier_type": "MOV",
+                },
+                {
+                    "file_name": "file.mp4",
+                },
+            ),  # Non-DCP/DPX test case
+        ]
+        self.test_records = [
+            Record(
+                keys=["recordId", "modId", "file_path", "specific_carrier_type"],
+                values=[
+                    index,
+                    0,
+                    test_case[0]["file_path"],
+                    test_case[0]["specific_carrier_type"],
+                ],
+            )
+            for index, test_case in enumerate(test_cases)
+        ]
+        self.expected_results = [test_case[1] for test_case in test_cases]
+
+    def test_get_file_path_info(self):
+        """Test that `get_file_path_info` correctly extracts file path info from FM records."""
+        for record, expected_result in zip(self.test_records, self.expected_results):
+            with self.subTest(record=record):
+                self.assertDictEqual(
+                    get_file_path_info(record),
                     expected_result,
                 )


### PR DESCRIPTION
Implements [DLSR-448](https://uclalibrary.atlassian.net/browse/DLSR-448)

## Acceptance criteria
- [X] The package handles new logic for new digital media (NDM) records, as described in the [NDM ETL](https://uclalibrary.atlassian.net/wiki/spaces/pm/pages/1818525700/NDM+ETL) specs
- [X] Where possible, code is reused from metadata generation for legacy media

## Description
This PR implements the NDM metadata logic described in the specs linked above. It updates `mams_metadata_ndm.py` to assemble metadata records from NDM records originating in Filemaker, plus optional Alma and `match_asset` data. The code reuses existing functions imported from `filemaker.py` and `marc.py` where possible. It adds functions for retrieving the following fields from Filemaker, which differ from the legacy metadata:

**Fields that come from Digital Data in legacy**
  - `uuid`, `asset_type`, `media_type`, `audio_class`, file path info

**New fields from FM item unit records**
  - `creation_date` and `source_ids`

Plural fields (`inventory_ids`, `inventory_numbers`, `source_ids`) are parsed from comma-separated Filemaker values. To avoid breaking existing consumers of the legacy `mams_metadata.py` module, functions for plural `inventory_ids` and `inventory_numbers` are added, rather than updating the functions that return the values as-is.

**Note about file paths**: the `file_path` field in Filemaker seems to always have Windows-style paths, but the `get_file_path_info()` function handles both Windows and POSIX paths just in case. The function looks for double forward-slashes (`\\`) to determine if a string represents a Windows path, which is maybe a little naive, but should work for now.

Compared with `mams_metadata.py`, `mams_metadata_ndm.py` is simpler, opting for inline assembly of the metadata making liberal use of dictionary unpacking, rather than using helper functions that return parts of the final dict. To me, this was clearer to reason with, but let me know if you don't like it, and I can go back to using helper functions. One other difference with the main coordinating `get_mams_metadata_ndm()` function here is that it returns a dict with alphabetically sorted keys, just to make review of the outputs a little easier.

The package version is bumped to `v0.6.0` in `pyproject.toml`.

## Testing
Unit tests were added and updated for the new Filemaker getters and related NDM logic. All 46 tests pass: `python -m unittest discover tests`.

[DLSR-448]: https://uclalibrary.atlassian.net/browse/DLSR-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ