### PR TITLE
DLSR-486: Override media type for DPX records from "Image" to "Video"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.6.1 - 2026-07-24
+### Changed
+- Updated `get_media_type()` logic to classify DPX as "Video" rather than "Image", as MAMS expects
+
 ## 0.6.0 - 2026-07-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.6.0"
+version = "0.6.1"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -268,6 +268,11 @@ def get_media_type(fm_inventory_record: Record) -> str:
         message = f"Invalid media type '{media_type}' for record {fm_inventory_record.recordId}"
         logger.error(message)
         raise ValueError(message)
+    # Special case for DPX: override the media type to "Video".
+    # FTVA's technical metadata tool identifies DPX frames as images, which they are,
+    # but MAMS expects DPX to be classified as video.
+    if fm_inventory_record.specific_carrier_type.lower() == "dpx":
+        media_type = "Video"
     return media_type
 
 

--- a/tests/test_metadata/test_filemaker.py
+++ b/tests/test_metadata/test_filemaker.py
@@ -434,8 +434,8 @@ class TestFilemakerMediaType(TestCase):
         for media_type in ["Audio", "Image", "Video"]:
             with self.subTest(media_type=media_type):
                 record = Record(
-                    keys=["recordId", "modId", "media_type"],
-                    values=[1, 0, media_type],
+                    keys=["recordId", "modId", "media_type", "specific_carrier_type"],
+                    values=[1, 0, media_type, ""],  # specific_carrier_type not relevant here
                 )
                 self.assertEqual(get_media_type(record), media_type)
 
@@ -444,8 +444,8 @@ class TestFilemakerMediaType(TestCase):
         for media_type in ["Film", ""]:
             with self.subTest(media_type=media_type):
                 record = Record(
-                    keys=["recordId", "modId", "media_type"],
-                    values=[1, 0, media_type],
+                    keys=["recordId", "modId", "media_type", "specific_carrier_type"],
+                    values=[1, 0, media_type, ""],  # specific_carrier_type not relevant here
                 )
                 with self.assertLogs(fm_module_logger, level="ERROR") as log_context:
                     with self.assertRaises(ValueError) as error_context:
@@ -455,6 +455,14 @@ class TestFilemakerMediaType(TestCase):
                 self.assertIn(expected_message, str(error_context.exception))
                 # Assert that the logs contain the expected message
                 self.assertIn(expected_message, log_context.output[0])
+
+    def test_dpx_media_type_override(self):
+        """Test that DPX media type is overridden to 'Video'."""
+        record = Record(
+            keys=["recordId", "modId", "media_type", "specific_carrier_type"],
+            values=[1, 0, "Image", "DPX"],
+        )
+        self.assertEqual(get_media_type(record), "Video")
 
 
 class TestFilemakerAudioClass(TestCase):


### PR DESCRIPTION
Implements [DLSR-486](https://uclalibrary.atlassian.net/browse/DLSR-486)

## Acceptance criteria
- [X] All DPX files have `media_type` set to "Video" for the NDM ETL process

## Description
Per conversation on [Slack](https://uclalibrary.slack.com/archives/C0893DA0TL0/p1784837928659069?thread_ts=1784826680.973629&cid=C0893DA0TL0), FTVA uses MediaInfo to extract technical metadata on media files described in Filemaker. MediaInfo (correctly) identifies DPX frames as images, but the MAMS expects DPX to be classified as "Video" in the `media_type` field.

This PR adds a conditional to the `filemaker.get_media_type()` to set the `media_type` field on all DPX records to "Video".

The package version is bumped to `v0.6.1`.

## Testing
One unit test is added to cover the new behavior. There are now 48 tests, all passing: `python -m unittest discover tests`

[DLSR-486]: https://uclalibrary.atlassian.net/browse/DLSR-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ