### PR TITLE
DLSR-510: Update field names in NDM metadata output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 0.6.2 - 2026-07-30
+### Changed
+- Updated field names to align with what MAMS expects:
+  - `inventory_ids` -> `inventory_id`
+  - `source_ids` -> `source_identifier`
+  - NOTE: The MAMS expects the keys `inventory_id` and `source_identifier` (singular) for these data fields, even though the values are lists of strings. The keys are not pluralized, but the values are still lists. We are accepting this inconsistency to avoid costly changes in the MAMS.
+
 ## 0.6.1 - 2026-07-24
 ### Changed
 - Updated `get_media_type()` logic to classify DPX as "Video" rather than "Image", as MAMS expects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.6.1"
+version = "0.6.2"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @deprecated(
-    "Use `get_inventory_ids()` instead, as MAMS expects `inventory_ids: list[str]`"
+    "Use `get_inventory_ids()` instead, as MAMS expects `inventory_id: list[str]`"
 )
 def get_inventory_id(fm_record: Record) -> str:
     """Get the inventory id from a Filemaker record.

--- a/src/ftva_etl/metadata/mams_metadata_ndm.py
+++ b/src/ftva_etl/metadata/mams_metadata_ndm.py
@@ -57,9 +57,12 @@ def get_mams_metadata_ndm(
 
     # These fields are derived from `fm_inventory_record`...
     fm_inventory_record_metadata = {
-        "inventory_ids": get_inventory_ids(fm_inventory_record),
+        # NOTE: The MAMS expects the keys `inventory_id` and `source_identifier` (singular),
+        # even though the values are lists of strings.
+        # We are accepting the inconsistency here because it is difficult to change the MAMS.
+        "inventory_id": get_inventory_ids(fm_inventory_record),
+        "source_identifier": get_source_ids(fm_inventory_record),
         "inventory_numbers": get_inventory_numbers(fm_inventory_record),
-        "source_ids": get_source_ids(fm_inventory_record),
         "creators": get_fm_creators(fm_inventory_record),
         "language": get_fm_language_name(fm_inventory_record),
         "asset_type": get_asset_type(fm_inventory_record),


### PR DESCRIPTION
Implements [DLSR-510](https://jira.library.ucla.edu/browse/DLSR-510)

## Acceptance criteria
- The field names output for NDM metadata are updated as follows:
  - inventory_ids → inventory_id 
  - source_ids → source_identifier

## Description
Updates the NDM metadata output so it uses the field names expected by the MAMS for inventory IDs and source identifiers, as shown above.

This keeps the output aligned with the MAMS without requiring changes there, though it does result in inconsistent and potentially confusing fields in the metadata output. I added a note on the relevant code, and Confluence documentation is being updated separately.

## Testing
No new tests added, and all existing tests still pass.

[DLSR-510]: https://uclalibrary.atlassian.net/browse/DLSR-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ