### PR TITLE
DLSR-515: Lowercase `media_type` outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.6.3 - 2026-07-31
+### Changed
+- Updated `get_media_type()` logic to return lowercased values for media type, as MAMS expects
+
 ## 0.6.2 - 2026-07-30
 ### Changed
 - Updated field names to align with what MAMS expects:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.6.2"
+version = "0.6.3"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -261,19 +261,21 @@ def get_media_type(fm_inventory_record: Record) -> str:
     :param fm_inventory_record: A Filemaker inventory record.
     :return: The media type as a string.
     """
-    # Specs require media type to be one of "Audio", "Image", or "Video",
-    # raising an error if it's not
+    # Specs require media type input to be one of "Audio", "Image", or "Video",
+    # raising an error if it's not.
+    # Return value should be lowercased, to match what MAMS expects.
     media_type = fm_inventory_record.media_type
     if media_type not in ["Audio", "Image", "Video"]:
         message = f"Invalid media type '{media_type}' for record {fm_inventory_record.recordId}"
         logger.error(message)
         raise ValueError(message)
-    # Special case for DPX: override the media type to "Video".
+    # Special case for DPX: override the media type to "video".
     # FTVA's technical metadata tool identifies DPX frames as images, which they are,
     # but MAMS expects DPX to be classified as video.
     if fm_inventory_record.specific_carrier_type.lower() == "dpx":
-        media_type = "Video"
-    return media_type
+        media_type = "video"
+    # MAMS expects lowercase value
+    return media_type.lower()
 
 
 def get_audio_class(fm_item_record: Record) -> str:

--- a/tests/test_metadata/test_filemaker.py
+++ b/tests/test_metadata/test_filemaker.py
@@ -437,7 +437,8 @@ class TestFilemakerMediaType(TestCase):
                     keys=["recordId", "modId", "media_type", "specific_carrier_type"],
                     values=[1, 0, media_type, ""],  # specific_carrier_type not relevant here
                 )
-                self.assertEqual(get_media_type(record), media_type)
+                # Output should be lowercased
+                self.assertEqual(get_media_type(record), media_type.lower())
 
     def test_invalid_media_type_logs_and_raises(self):
         """Test that non-allowlisted values log an error then raise ValueError."""
@@ -462,7 +463,7 @@ class TestFilemakerMediaType(TestCase):
             keys=["recordId", "modId", "media_type", "specific_carrier_type"],
             values=[1, 0, "Image", "DPX"],
         )
-        self.assertEqual(get_media_type(record), "Video")
+        self.assertEqual(get_media_type(record), "video")
 
 
 class TestFilemakerAudioClass(TestCase):


### PR DESCRIPTION
## Acceptance criteria
- [X] Logic for `media_type` field normalizes values to lowercase in NDM ETL output (e.g. `Video` to `video`)
- [X] Any relevant tests are updated accordingly

## Description
Per discussion on [Slack](https://uclalibrary.slack.com/archives/C0893DA0TL0/p1785181892776149?thread_ts=1784922111.439949&cid=C0893DA0TL0), the MAMS scheduler uses the `media_type` field in its logic and expects a lowercase value for that field, as a lookup value. Previous specs had stated the field value in our JSON should use first-letter capitalization, but now we should normalize to lowercase.

## Testing
Tests are updated to reflect changes to transformer. 48 total tests; all passing.