### PR TITLE
DLSR-523: Align legacy ETL logic with specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+
+## 0.7.0 - 2026-08-06
+### Changed
+- Refactored legacy `mams_metadata.py` to mirror NDM `mams_metadata_ndm.py` module
+- Updated logic to align with current specs
+
 ## 0.6.3 - 2026-07-31
 ### Changed
 - Updated `get_media_type()` logic to return lowercased values for media type, as MAMS expects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["src/ftva_etl"]
 
 [project]
 name = "ftva_etl"
-version = "0.6.3"
+version = "0.7.0"
 description = "UCLA FTVA MAMS ETL utilities"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -37,14 +37,13 @@ def get_media_type(dd_record: dict) -> str:
     :param dd_record: A Digital Data record
     :return: The media type as a lowercasestring.
     """
-    # Specs require media type input to be one of "Audio", "Image", or "Video",
-    # raising an error if it's not.
-    # Return value should be lowercased, to match what MAMS expects.
+    # Raise an error if the media type is not one of "audio", "image", or "video"
     media_type = dd_record.get("media_type", "")
-    if media_type not in ["Audio", "Image", "Video"]:
+    if media_type.lower() not in ["audio", "image", "video"]:
         message = f"Invalid media type '{media_type}' for record {get_dd_record_id(dd_record)}"
         logger.error(message)
         raise ValueError(message)
+    # Ensure return value is lowercase, as MAMS expects
     return media_type.lower()
 
 

--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -59,8 +59,7 @@ def get_dcp_info(dd_record: dict) -> dict:
     return {
         # File name must always be empty for DCPs.
         "file_name": "",
-        "folder_name": get_folder_name(dd_record),
-        "sub_folder_name": get_sub_folder_name(dd_record),
+        "folder_name": get_sub_folder_name(dd_record) or get_folder_name(dd_record),
         "file_type": "DCP",  # file type required by MAMS for DCP files
     }
 

--- a/src/ftva_etl/metadata/digital_data.py
+++ b/src/ftva_etl/metadata/digital_data.py
@@ -1,6 +1,10 @@
-# Code which extracts data from a Digital Data record.
-# Minimal for now.
+import logging
 from uuid import UUID
+
+# Code which extracts data from a Digital Data record.
+
+# Create a module logger, which will be a child of the package logger
+logger = logging.getLogger(__name__)
 
 
 def get_file_name(dd_record: dict) -> str:
@@ -28,7 +32,20 @@ def get_asset_type(dd_record: dict) -> str:
 
 
 def get_media_type(dd_record: dict) -> str:
-    return dd_record.get("media_type", "")
+    """Get the media type from a Digital Data record.
+
+    :param dd_record: A Digital Data record
+    :return: The media type as a lowercasestring.
+    """
+    # Specs require media type input to be one of "Audio", "Image", or "Video",
+    # raising an error if it's not.
+    # Return value should be lowercased, to match what MAMS expects.
+    media_type = dd_record.get("media_type", "")
+    if media_type not in ["Audio", "Image", "Video"]:
+        message = f"Invalid media type '{media_type}' for record {get_dd_record_id(dd_record)}"
+        logger.error(message)
+        raise ValueError(message)
+    return media_type.lower()
 
 
 def get_dcp_info(dd_record: dict) -> dict:

--- a/src/ftva_etl/metadata/filemaker.py
+++ b/src/ftva_etl/metadata/filemaker.py
@@ -3,25 +3,11 @@ import logging
 from fmrest.record import Record
 from pathlib import PureWindowsPath, PurePosixPath
 from .utils import cleanup_production_type, parse_date, format_date
-from warnings import deprecated
-
 
 # Code which extracts data from a Filemaker record.
 
 # Create a module logger, which will be a child of the package logger
 logger = logging.getLogger(__name__)
-
-
-@deprecated(
-    "Use `get_inventory_ids()` instead, as MAMS expects `inventory_id: list[str]`"
-)
-def get_inventory_id(fm_record: Record) -> str:
-    """Get the inventory id from a Filemaker record.
-
-    :param fm_record: A Filemaker record.
-    :return: The inventory id as a string.
-    """
-    return str(fm_record.inventory_id)
 
 
 def get_inventory_ids(fm_inventory_record: Record) -> list[str]:
@@ -35,18 +21,6 @@ def get_inventory_ids(fm_inventory_record: Record) -> list[str]:
         inventory_id.strip()
         for inventory_id in str(fm_inventory_record.inventory_id).split(",")
     ]
-
-
-@deprecated(
-    "Use `get_inventory_numbers()` instead, as MAMS expects `inventory_numbers: list[str]`"
-)
-def get_inventory_number(fm_record: Record) -> str:
-    """Get the inventory number from a Filemaker record.
-
-    :param fm_record: A Filemaker record.
-    :return: The inventory number as a string.
-    """
-    return fm_record.inventory_no
 
 
 def get_inventory_numbers(fm_inventory_record: Record) -> list[str]:

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -1,5 +1,4 @@
 import spacy
-import logging
 
 from fmrest.record import Record as FM_Record
 from pymarc import Record as Pymarc_Record
@@ -16,8 +15,8 @@ from .digital_data import (
     get_record_type_and_match_asset,
 )
 from .filemaker import (
-    get_inventory_id,
-    get_inventory_number,
+    get_inventory_ids,
+    get_inventory_numbers,
     is_series_production_type,
     get_creators as get_fm_creators,
     get_date_info as get_fm_date_info,
@@ -31,74 +30,6 @@ from .marc import (
     get_language_name as get_alma_language_name,
     get_title_info as get_alma_title_info,
 )
-
-
-# Create a module logger, which will be a child of the package logger
-logger = logging.getLogger(__name__)
-
-
-def get_alma_metadata(
-    bib_record: Pymarc_Record, nlp_model: Language, is_series: bool = False
-) -> dict:
-    """Get the Alma metadata from a pymarc record.
-
-    :param bib_record: A pymarc record.
-    :param nlp_model: A spacy language model to use for NER.
-    :param is_series: Whether the record is a series, derived from Filemaker record.
-        Defaults to False.
-    :return: A dict containing the Alma metadata needed for the MAMS.
-    """
-    # This gets a collection of titles which will be unpacked later.
-    titles = get_alma_title_info(bib_record, is_series)
-    return {
-        "alma_bib_id": get_bib_id(bib_record),
-        "language": get_alma_language_name(bib_record),
-        "creators": get_alma_creators(bib_record, nlp_model),
-        **titles,
-        **get_alma_date_info(bib_record),
-    }
-
-
-def get_filemaker_metadata(filemaker_record: FM_Record, is_series: bool) -> dict:
-    """Get the Filemaker metadata from a Filemaker record.
-
-    :param filemaker_record: A Filemaker record.
-    :param is_series: Whether the record is a series, derived from Filemaker record.
-    :return: A dict containing the Filemaker metadata needed for the MAMS.
-    """
-    titles = get_fm_title_info(filemaker_record, is_series)
-    return {
-        "inventory_id": get_inventory_id(filemaker_record),
-        # All records returned from FM
-        # should have only one inventory number for now,
-        # but MAMS expects an array in JSON, so wrap in a list.
-        # TODO: Parse comma-separated or otherwise delimited inventory numbers
-        # from FM or other sources, if needed.
-        "inventory_numbers": [get_inventory_number(filemaker_record)],
-        "creators": get_fm_creators(filemaker_record),
-        "language": get_fm_language_name(filemaker_record),
-        **titles,
-        **get_fm_date_info(filemaker_record),
-    }
-
-
-def _get_descriptive_metadata(source_metadata: dict) -> dict:
-    """Utility for extracting descriptive metadata fields from the provided source,
-    i.e. `creators`, `language`, and all title and date fields.
-    Since these fields are common to both Alma and Filemaker sources,
-    and Alma is preferred as a source when present, but is not required,
-    this function is a reusable utility for extracting these fields from either source.
-
-    :param source_metadata: A dict containing source metadata (i.e. either from Filemaker or Alma).
-    :return: A dict containing descriptive metadata fields from the source metadata.
-    """
-    output = {
-        "creators": source_metadata.get("creators", []),
-        "language": source_metadata.get("language", ""),
-        **{k: v for k, v in source_metadata.items() if "title" in k},
-        **{k: v for k, v in source_metadata.items() if "date" in k},
-    }
-    return output
 
 
 def get_mams_metadata(
@@ -125,12 +56,6 @@ def get_mams_metadata(
     # Filemaker is the source-of-truth for whether something is a series.
     is_series = is_series_production_type(filemaker_record)
 
-    filemaker_metadata = get_filemaker_metadata(filemaker_record, is_series)
-
-    alma_metadata = (
-        get_alma_metadata(bib_record, nlp_model, is_series) if bib_record else {}
-    )
-
     # These are all the fields derived from the Digital Data app
     digital_data_fields = {
         "uuid": get_uuid(digital_data_record),
@@ -145,10 +70,30 @@ def get_mams_metadata(
 
     # These are the fields from Filemaker
     filemaker_fields = {
-        "inventory_id": filemaker_metadata.get("inventory_id", ""),
-        "inventory_numbers": filemaker_metadata.get("inventory_numbers", []),
-        **_get_descriptive_metadata(filemaker_metadata),
+        "inventory_id": get_inventory_ids(filemaker_record),
+        # All records returned from FM
+        # should have only one inventory number for now,
+        # but MAMS expects an array in JSON, so wrap in a list.
+        # TODO: Parse comma-separated or otherwise delimited inventory numbers
+        # from FM or other sources, if needed.
+        "inventory_numbers": get_inventory_numbers(filemaker_record),
+        "creators": get_fm_creators(filemaker_record),
+        "language": get_fm_language_name(filemaker_record),
+        **get_fm_title_info(filemaker_record, is_series),
+        **get_fm_date_info(filemaker_record),
     }
+
+    alma_metadata = (
+        {
+            "alma_bib_id": get_bib_id(bib_record),
+            "language": get_alma_language_name(bib_record),
+            "creators": get_alma_creators(bib_record, nlp_model),
+            **get_alma_title_info(bib_record, is_series),
+            **get_alma_date_info(bib_record),
+        }
+        if bib_record
+        else {}
+    )
 
     # Combine fields from Digital Data and Filemaker into a single metadata object...
     metadata = {
@@ -158,10 +103,7 @@ def get_mams_metadata(
 
     # ...and if Alma metadata is available, update the metadata dict with Alma fields
     if alma_metadata:
-        alma_fields = {
-            "alma_bib_id": alma_metadata.get("alma_bib_id", ""),
-            **_get_descriptive_metadata(alma_metadata),
-        }
-        metadata.update(alma_fields)
+        metadata.update(alma_metadata)
 
-    return metadata
+    # Sort the output dict by its keys, just to make review easier
+    return dict(sorted(metadata.items()))

--- a/src/ftva_etl/metadata/mams_metadata.py
+++ b/src/ftva_etl/metadata/mams_metadata.py
@@ -70,12 +70,11 @@ def get_mams_metadata(
 
     # These are the fields from Filemaker
     filemaker_fields = {
+        # NOTE: The MAMS expects the key `inventory_id` (singular),
+        # even though the value is a list of strings.
+        # This is inconsistent with the use of `inventory_numbers` (plural),
+        # but we are accepting the inconsistency here because it is difficult to change the MAMS.
         "inventory_id": get_inventory_ids(filemaker_record),
-        # All records returned from FM
-        # should have only one inventory number for now,
-        # but MAMS expects an array in JSON, so wrap in a list.
-        # TODO: Parse comma-separated or otherwise delimited inventory numbers
-        # from FM or other sources, if needed.
         "inventory_numbers": get_inventory_numbers(filemaker_record),
         "creators": get_fm_creators(filemaker_record),
         "language": get_fm_language_name(filemaker_record),

--- a/src/ftva_etl/metadata/mams_metadata_ndm.py
+++ b/src/ftva_etl/metadata/mams_metadata_ndm.py
@@ -59,7 +59,8 @@ def get_mams_metadata_ndm(
     fm_inventory_record_metadata = {
         # NOTE: The MAMS expects the keys `inventory_id` and `source_identifier` (singular),
         # even though the values are lists of strings.
-        # We are accepting the inconsistency here because it is difficult to change the MAMS.
+        # This is inconsistent with the use of `inventory_numbers` (plural),
+        # but we are accepting the inconsistency here because it is difficult to change the MAMS.
         "inventory_id": get_inventory_ids(fm_inventory_record),
         "source_identifier": get_source_ids(fm_inventory_record),
         "inventory_numbers": get_inventory_numbers(fm_inventory_record),

--- a/src/ftva_etl/metadata/marc.py
+++ b/src/ftva_etl/metadata/marc.py
@@ -134,6 +134,7 @@ def _parse_creators(source_string: str, model: Language) -> list[str]:
         "director",  # This will also match "directors" or "producer-director"
         "a film by",
         "supervised by",
+        "filmmaker",
     ]
 
     # Find the first attribution phrase in the source string,

--- a/tests/test_metadata/test_digital_data.py
+++ b/tests/test_metadata/test_digital_data.py
@@ -7,7 +7,7 @@ from src.ftva_etl.metadata.digital_data import (
 
 
 class TestDigitalData(TestCase):
-    def test_dcp_info(self):
+    def test_dcp_info_with_sub_folder(self):
         # Very simple Digital Data record for DCP.
         dcp_record = {
             "file_type": "DCP",
@@ -21,8 +21,27 @@ class TestDigitalData(TestCase):
         self.assertEqual(dcp_info["file_name"], "")
         # Other values should match.
         # Note that these methods may rename some field names, which is intentional.
+        # If a sub folder name is present, it should be used in place of the folder name.
+        self.assertEqual(dcp_info["folder_name"], "sub folder name")
+        # `file_type` should be "DCP"
+        self.assertEqual(dcp_info["file_type"], "DCP")
+
+    def test_dcp_info_without_sub_folder(self):
+        # Very simple Digital Data record for DCP.
+        dcp_record = {
+            "file_type": "DCP",
+            "file_name": "not relevant",
+            "file_folder_name": "folder name",
+            "sub_folder_name": "",
+        }
+
+        dcp_info = get_dcp_info(dcp_record)
+        # File name must be empty.
+        self.assertEqual(dcp_info["file_name"], "")
+        # Other values should match.
+        # Note that these methods may rename some field names, which is intentional.
+        # If there isno sub-folder name, the folder name should be used.
         self.assertEqual(dcp_info["folder_name"], "folder name")
-        self.assertEqual(dcp_info["sub_folder_name"], "sub folder name")
         # `file_type` should be "DCP"
         self.assertEqual(dcp_info["file_type"], "DCP")
 


### PR DESCRIPTION
Implements [DLSR-523](https://uclalibrary.atlassian.net/browse/DLSR-523)

## Acceptance criteria
- [X] Legacy ETL logic in `mams_metadata.py` aligns with the current specs documented in [the Confluence page](https://uclalibrary.atlassian.net/wiki/x/AYCoY)
- [X] Tests are updated as needed

## Summary
This PR does the following:
- Refactors the legacy `mams_metadata.py` module to match the style of the NDM module `mams_metadata_ndm.py`
- Aligns legacy ETL logic with current FTVA specs, specifically by updating handling of:
  - the `media_type` getter in `digital_data.py`;
  - the `get_dcp_info` function in `digital_data.py`; and,
  - the creators logic in `marc.py`
- Switches `inventory_id` derived from Filemaker to a list of strings
- Updates the way `inventory_numbers` is set as a list of strings
- Removes unused, deprecated functions from `filemaker.py`

## Testing
No new tests are added, but a few tests are updated to align with revised logic. There are 49 tests, all passing.

[DLSR-523]: https://uclalibrary.atlassian.net/browse/DLSR-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ